### PR TITLE
Add charmed kubeflow beta release banner

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -26,6 +26,9 @@
 {% endmacro %}
 
 <section class="p-strip u-extra-space">
+  {% if not date_has_passed("2022-09-06") %}
+    {% include "partial/_beta-banner.html" %}
+  {% endif %}
   <div class="row">
     <aside class="col-3">
       {% if versions | length > 1 %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,9 @@
 
 {% block content %}
 <section class="p-strip--suru">
+  {% if not date_has_passed("2022-09-06") %}
+    {% include "partial/_beta-banner.html" %}
+  {% endif %}
   <div class="row u-equal-height">
     <div class="col-6 u-vertically-center">
       <div>

--- a/templates/partial/_beta-banner.html
+++ b/templates/partial/_beta-banner.html
@@ -1,0 +1,15 @@
+<div class="u-fixed-width">
+  <div class="p-notification--information is-inline">
+    <div class="p-notification__content">
+      <h5 class="p-notification__title">
+        The Charmed Kubeflow 1.6 beta is here:
+      </h5>
+      <p class="p-notification__message">
+        <code>juju deploy kubeflow --channel 1.6/beta</code><br /> Read more in our
+        <a href="/blog/kubeflow-beta-release-mlops">blog</a> and share your
+        <a href="https://discourse.charmhub.io/t/kubeflow-1-6/6842">feedback</a>
+        with us.
+      </p>
+    </div>
+  </div>
+</div>

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -6,6 +6,9 @@
 
 {% block content %}
 <section class="p-strip--suru-dark">
+  {% if not date_has_passed("2022-09-07") %}
+    {% include "partial/_beta-banner.html" %}
+  {% endif %}
   <div class="u-fixed-width">
     <h1>Tutorials</h1>
   </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import talisker.requests
 
 # Packages
@@ -37,9 +38,18 @@ main_docs.init_app(app)
 init_tutorials(app, "/tutorials")
 
 
+def date_has_passed(date_str):
+    try:
+        date = datetime.strptime(date_str, "%Y-%m-%d")
+        present = datetime.now()
+        return present > date
+    except ValueError:
+        return False
+
+
 @app.context_processor
 def utility_processor():
-    return {"image": image_template}
+    return {"image": image_template, "date_has_passed": date_has_passed}
 
 
 @app.route("/")


### PR DESCRIPTION
## Done

Add charmed kubeflow beta release banner
Added `date_has_passed` template filter

## QA

- Check banner shows on https://charmed-kubeflow-io-124.demos.haus/tutorials, https://charmed-kubeflow-io-124.demos.haus/, and https://charmed-kubeflow-io-124.demos.haus/docs/
- Blog link won't work until 17-08-2022

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5801#event-7187095963

## Screenshots

![charmed-kubeflow-banner](https://user-images.githubusercontent.com/14939793/184637661-453812ab-687b-454f-92f4-0a488f91e2aa.png)

