### PR TITLE
fix blog link on beta banner

### DIFF
--- a/templates/partial/_beta-banner.html
+++ b/templates/partial/_beta-banner.html
@@ -6,7 +6,7 @@
       </h5>
       <p class="p-notification__message">
         <code>juju deploy kubeflow --channel 1.6/beta</code><br /> Read more in our
-        <a href="/blog/kubeflow-beta-release-mlops">blog</a> and share your
+        <a href="https://ubuntu.com/blog/kubeflow-beta-release-mlops">blog</a> and share your
         <a href="https://discourse.charmhub.io/t/kubeflow-1-6/6842">feedback</a>
         with us.
       </p>


### PR DESCRIPTION
## Done

Fixed blog link on beta banner, to point to absolute path (https://ubuntu.com/blog/kubeflow-beta-release-mlops), rather than relative (/blog/kubeflow-beta-release-mlops)