### PR TITLE
Implement expandable side-nav and search for /docs 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 canonicalwebteam.flask-base==1.0.6
 canonicalwebteam.discourse==5.0.3
 canonicalwebteam.image-template==1.3.1
+canonicalwebteam.search==1.2.7
+

--- a/static/js/side-navigation.js
+++ b/static/js/side-navigation.js
@@ -1,0 +1,160 @@
+(function () {
+  /**
+    Toggles the expanded/collapsed classed on side navigation element.
+
+    @param {HTMLElement} sideNavigation The side navigation element.
+    @param {Boolean} show Whether to show or hide the drawer.
+  */
+  function toggleDrawer(sideNavigation, show) {
+    const toggleButtonOutsideDrawer = sideNavigation.querySelector(
+      ".p-side-navigation__toggle"
+    );
+    const toggleButtonInsideDrawer = sideNavigation.querySelector(
+      ".p-side-navigation__toggle--in-drawer"
+    );
+
+    if (sideNavigation) {
+      if (show) {
+        sideNavigation.classList.remove("is-drawer-collapsed");
+        sideNavigation.classList.add("is-drawer-expanded");
+
+        toggleButtonInsideDrawer.focus();
+        toggleButtonOutsideDrawer.setAttribute("aria-expanded", true);
+        toggleButtonInsideDrawer.setAttribute("aria-expanded", true);
+      } else {
+        sideNavigation.classList.remove("is-drawer-expanded");
+        sideNavigation.classList.add("is-drawer-collapsed");
+
+        toggleButtonOutsideDrawer.focus();
+        toggleButtonOutsideDrawer.setAttribute("aria-expanded", false);
+        toggleButtonInsideDrawer.setAttribute("aria-expanded", false);
+      }
+    }
+  }
+
+  // throttle util (for window resize event)
+  var throttle = function (fn, delay) {
+    var timer = null;
+    return function () {
+      var context = this,
+        args = arguments;
+      clearTimeout(timer);
+      timer = setTimeout(function () {
+        fn.apply(context, args);
+      }, delay);
+    };
+  };
+
+  /**
+    Attaches event listeners for the side navigation toggles
+    @param {HTMLElement} sideNavigation The side navigation element.
+  */
+  function setupSideNavigation(sideNavigation) {
+    var toggles = [].slice.call(
+      sideNavigation.querySelectorAll(".js-drawer-toggle")
+    );
+    var drawerEl = sideNavigation.querySelector(".p-side-navigation__drawer");
+
+    // hide navigation drawer on small screens
+    sideNavigation.classList.add("is-drawer-hidden");
+
+    // setup drawer element
+    drawerEl.addEventListener("animationend", () => {
+      if (!sideNavigation.classList.contains("is-drawer-expanded")) {
+        sideNavigation.classList.add("is-drawer-hidden");
+      }
+    });
+
+    window.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        toggleDrawer(sideNavigation, false);
+      }
+    });
+
+    // setup toggle buttons
+    toggles.forEach(function (toggle) {
+      toggle.addEventListener("click", function (event) {
+        event.preventDefault();
+
+        if (sideNavigation) {
+          sideNavigation.classList.remove("is-drawer-hidden");
+          toggleDrawer(
+            sideNavigation,
+            !sideNavigation.classList.contains("is-drawer-expanded")
+          );
+        }
+      });
+    });
+
+    // hide side navigation drawer when screen is resized
+    window.addEventListener(
+      "resize",
+      throttle(function () {
+        toggles.forEach((toggle) => {
+          return toggle.setAttribute("aria-expanded", false);
+        });
+        // remove expanded/collapsed class names to avoid unexpected animations
+        sideNavigation.classList.remove("is-drawer-expanded");
+        sideNavigation.classList.remove("is-drawer-collapsed");
+        sideNavigation.classList.add("is-drawer-hidden");
+      }, 10)
+    );
+  }
+
+  /**
+    Attaches event listeners for all the side navigations in the document.
+    @param {String} sideNavigationSelector The CSS selector matching side navigation elements.
+  */
+  function setupSideNavigations(sideNavigationSelector) {
+    // Setup all side navigations on the page.
+    var sideNavigations = [].slice.call(
+      document.querySelectorAll(sideNavigationSelector)
+    );
+
+    sideNavigations.forEach(setupSideNavigation);
+  }
+
+  setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');
+
+  // Setup expandable side navigation
+
+  var expandToggles = document.querySelectorAll(".p-side-navigation__expand");
+  var navigationLinks = document.querySelectorAll(".p-side-navigation__link");
+
+  // setup default values of aria-expanded for the toggle button, list title and list itself
+  const setup = (toggle) => {
+    const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+    if (!isExpanded) {
+      toggle.setAttribute("aria-expanded", isExpanded);
+    }
+    const item = toggle.closest(".p-side-navigation__item");
+    const link = item.querySelector(".p-side-navigation__link");
+    const nestedList = item.querySelector(".p-side-navigation__list");
+    if (!link?.hasAttribute("aria-expanded")) {
+      link.setAttribute("aria-expanded", isExpanded);
+    }
+    if (!nestedList?.hasAttribute("aria-expanded")) {
+      nestedList.setAttribute("aria-expanded", isExpanded);
+    }
+  };
+
+  const handleToggle = (e) => {
+    const item = e.currentTarget.closest(".p-side-navigation__item");
+    const button = item.querySelector(".p-side-navigation__expand");
+    const link = item.querySelector(".p-side-navigation__link");
+    const nestedList = item.querySelector(".p-side-navigation__list");
+    [button, link, nestedList].forEach((el) =>
+      el.setAttribute(
+        "aria-expanded",
+        el.getAttribute("aria-expanded") === "true" ? "false" : "true"
+      )
+    );
+  };
+
+  expandToggles.forEach((toggle) => {
+    setup(toggle);
+    toggle.addEventListener("click", (e) => {
+      handleToggle(e);
+    });
+  });
+})();

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -5,30 +5,50 @@
 {% block title %}{{ document.title }} | Documentation{% endblock %}
 
 {% block content %}
-{% macro create_navigation(nav_items) %}
-  <ul>
+{% macro create_navigation(nav_items, expandable=False, expanded=False) %}
+  <ul class="p-side-navigation__list">
     {% for element in nav_items %}
-    <li>
+    <li class="p-side-navigation__item">
       {% if element.navlink_href %}
-        <a href="{{ element.navlink_href }}"
-          {% if request.path == element.navlink_href %}aria-current="page"{% endif %}
-        >{{ element.navlink_text }}</a>
+      <a
+        class="p-side-navigation__link {% if expandable and element.children %}is-expandable{% endif %}"
+        href="{{ element.navlink_href }}"
+        {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
+        {% if element.is_active %}aria-current="page"{% endif %}
+      >{{ element.navlink_text }}</a>
       {% else %}
-        <strong>{{ element.navlink_text }}</strong>
+        <span
+          class="p-side-navigation__text {% if expandable and element.children %}is-expandable{% endif %}"
+          {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
+          {% if element.is_active %}aria-current="page"{% endif %}
+        >{{ element.navlink_text }}</span>
       {% endif %}
 
-      {% if element.children %}
-        {{ create_navigation(element.children) }}
+      {% if expandable %}
+        {% if element.children %}
+            <button class="p-side-navigation__expand" aria-expanded={% if element.is_active or element.has_active_child %}"true"{% else %}"false"{% endif %} aria-label="show submenu for {{ element.navlink_text }}"></button>
+        {% endif %}
+        {{ create_navigation(element.children, expandable, element.is_active or element.has_active_child) }}
+      {% else %}
+        {% if element.children %}
+          {{ create_navigation(element.children, expandable) }}
+        {% endif %}
       {% endif %}
     </li>
     {% endfor %}
   </ul>
 {% endmacro %}
 
+<section id="search-docs" class="p-strip--light is-shallow">
+  <div class="row">
+    <form class="p-search-box u-no-margin--bottom" action="/docs/search">
+      <input type="search" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search documentation" required/>
+      <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search">Search</i></button>
+    </form>
+  </div>
+</section>
+
 <section class="p-strip u-extra-space">
-  {% if not date_has_passed("2022-09-06") %}
-    {% include "partial/_beta-banner.html" %}
-  {% endif %}
   <div class="row">
     <aside class="col-3">
       {% if versions | length > 1 %}
@@ -41,7 +61,7 @@
       <select>
       {% endif %}
 
-      <nav data-js="navigation" class="p-side-navigation--raw-html" id="{{ navigation['path'] or 'default' }}">
+      <nav data-js="navigation" class="p-side-navigation" id="{{ navigation['path'] or 'default' }}">
         <a href="#{{ navigation['path'] or 'default' }}" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="{{ navigation['path'] or 'default' }}">
           Toggle side navigation
         </a>
@@ -53,18 +73,24 @@
             </a>
           </div>
           {% for nav_group in navigation.nav_items %}
-            {% if nav_group.navlink_href %}
-              <h3>
-                <a
-                  class="p-link--soft"
-                  href="{{ nav_group.navlink_href }}"
-                  {% if request.path == nav_group.navlink_href %}aria-current="page"{% endif %}
-                >{{ nav_group.navlink_text }}</a>
-            </h3>
-            {% elif nav_group.navlink_text %}
-               <h3>{{ nav_group.navlink_text }}</h3>
+          {% if not nav_group.hidden %}
+            {% if nav_group.navlink_text %}
+              {% if nav_group.navlink_href %}
+                <h3 class="p-side-navigation__heading--linked">
+                  <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active %}aria-current="page"{% endif %}>
+                    {{ nav_group.navlink_text }}
+                  </a>
+                </h3>
+              {% else %}
+                <h3 class="p-side-navigation__heading">{{ nav_group.navlink_text }}</h3>
+              {% endif %}
             {% endif %}
-            {{ create_navigation(nav_group.children) }}
+            {#
+              Use `create_navigation(nav_group.children)` for a default, fully expanded navigation.
+              Use `create_navigation(nav_group.children, expandable=True)` for the nested nav levels to expand only when parent page is active.
+            #}
+            {{ create_navigation(nav_group.children, expandable=True) }}
+          {% endif %}
           {% endfor %}
         </div>
       </nav>
@@ -84,4 +110,6 @@
 </section>
 
 <script src="{{ versioned_static('js/prism.js') }}"></script>
+<script src="{{ versioned_static('js/side-navigation.js') }}"></script>
+
 {% endblock %}

--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -25,7 +25,7 @@
     <div class="u-fixed-width">
       <form class="p-search-box u-no-margin--bottom" action="/docs/search">
         <label for="search-input" class="u-off-screen">Search</label>
-        <input class="p-search-box__input" name="q" id="search-input" type="search" {% if query %}value="{{ query }}"{% endif %} placeholder="e.g. multipass launch" />
+        <input class="p-search-box__input" name="q" id="search-input" type="search" {% if query %}value="{{ query }}"{% endif %} placeholder="e.g. microk8s status" />
         {% if siteSearch %}
           <input name="siteSearch" type="hidden" value="{{ siteSearch }}" />
         {% endif %}
@@ -80,8 +80,8 @@
           <div class="col-6">
             <h3>Still no luck?</h3>
             <ul class="p-list">
-              <li class="p-list__item is-ticked"><a href="/">Visit the Multipass homepage</a></li>
-              <li class="p-list__item is-ticked"><a href="https://discourse.ubuntu.com/c/multipass/21">Visit the forum</a></li>
+              <li class="p-list__item is-ticked"><a href="/">Visit the Charmed Kubeflow homepage</a></li>
+              <li class="p-list__item is-ticked"><a href="https://discourse.charmhub.io/tag/kubeflow">Visit the forum</a></li>
             </ul>
           </div>
         </div>

--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -1,41 +1,43 @@
 {% extends "base_layout.html" %}
 
-{% block meta %}
-    {{ super() }}
-    <meta name="robots" content="noindex" />
-{% endblock %}
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
-{% block page_class %}docs{% endblock %}
-{% block content_class %}l-docs-wrapper{% endblock %}
-{% block title %}Search results{% if query %} for "{{query}}"{% endif %}{% endblock %}
+{% block title %}Search results{% if query %} for "{{ query }}"{% endif %} | Ubuntu{% endblock %}
 
 {% block content %}
-  <section id="search-docs" class="p-strip--image is-shallow" style="background-image: url('https://assets.ubuntu.com/v1/e54487e2-maas-docs-suru.png')">
-    <div class="row">
+
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width">
+      {% if query %}
+        {% if estimatedTotal == 0 %}
+          <h1 class="p-heading--2">Sorry we couldn't find "{{ query }}" in docs</h1>
+        {% else %}
+          <h1 class="p-heading--2">Search results for "{{ query }}" in docs</h1>
+        {% endif %}
+      {% else %}
+        <h1>Search Ubuntu and Canonical sites</h1>
+      {% endif %}
+    </div>
+  </div>
+
+  {# search form #}
+  <div class="p-strip--light is-shallow">
+    <div class="u-fixed-width">
       <form class="p-search-box u-no-margin--bottom" action="/docs/search">
-        <input type="search" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search documentation" required/>
-        <button type="button" class="p-search-box__reset" alt="reset" onclick="this.previousElementSibling.value = '';this.previousElementSibling.focus()"><i class="p-icon--close">Reset</i></button>
-        <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search">Search</i></button>
+        <label for="search-input" class="u-off-screen">Search</label>
+        <input class="p-search-box__input" name="q" id="search-input" type="search" {% if query %}value="{{ query }}"{% endif %} placeholder="e.g. multipass launch" />
+        {% if siteSearch %}
+          <input name="siteSearch" type="hidden" value="{{ siteSearch }}" />
+        {% endif %}
+        <button type="submit" alt="search" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
       </form>
     </div>
-  </section>
+  </div>
 
-  <div class="l-docs">
-    <div class="p-strip is-shallow u-no-padding--bottom">
-      <div class="row">
-        <div class="col-12">
-          {% if results and results.entries %}
-            <h1 class="p-heading--2 u-no-margin--bottom">We've found these results for your search <strong>"{{ query }}"</strong></h1>
-          {% else %}
-            <h1 class="p-heading--2 u-no-margin--bottom">We haven't found any results for your search <strong>"{{ query }}"</strong>.</h1>
-          {% endif %}
-        </div>
-      </div>
-    </div>
-
-    {% if  results and results.entries %}
-        {% for item in results.entries %}
-        <div class="p-strip is-bordered is-shallow">
+  {% if results %}
+    {% if results.entries %}
+      {% for item in results.entries %}
+        <div class="p-strip is-shallow">
           <div class="row">
             <div class="col-12">
               <h5><a href="{{ item.link }}" class="title-main">{{ item.htmlTitle | safe}}</a></h5>
@@ -46,47 +48,44 @@
             </div>
           </div>
         </div>
-        {% endfor %}
-        <div class="p-strip p-article-pagination">
-            {% if  results.queries and results.queries.previousPage %}
-                <a
-                  class="p-article-pagination__link--previous"
-                  href="/docs/search?q={{ query }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
-                >
-                    <span class="p-article-pagination__label">Previous</span>
-                </a>
+      {% endfor %}
+
+      <div class="p-strip">
+        <div class="row">
+          <div class="col-6 u-align--left">
+            {% if results.queries and results.queries.previousPage %}
+              <a href="/docs/search?q={{ query }}&amp;start={{ results.queries.previousPage[0].startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}">&#8249;&nbsp;Previous</a>
             {% endif %}
+          </div>
+
+          <div class="col-6 u-align--right">
             {% if results.queries and results.queries.nextPage %}
-              <a
-                class="p-article-pagination__link--next"
-                href="/docs/search?q={{ query }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
-              >
-                <span class="p-article-pagination__label">Next</span>
-              </a>
+              <a href="/docs/search?q={{ query }}&amp;start={{ results.queries.nextPage[0].startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}">Next&nbsp;&#8250;</a>
             {% endif %}
-        </div>
-    {% else %}
-    <div class="p-strip">
-      <div class="row">
-        <div class="col-6">
-          <h3>Why not try widening your search?</h3>
-          <p>You can do this by:</p>
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">Adding alternative words or phrases</li>
-            <li class="p-list__item is-ticked">Using individual words instead of phrases</li>
-            <li class="p-list__item is-ticked">Trying a different spelling</li>
-          </ul>
-        </div>
-        <div class="col-6">
-          <h3>Still no luck?</h3>
-          <ul class="p-list">
-            <li class="p-list__item is-ticked"><a href="/docs">Visit charmed-kubeflow.io/docs</a></li>
-            <li class="p-list__item is-ticked"><a href="https://discourse.charmed-kubeflow.io">Ask on the forum</a></li>
-          </ul>
+          </div>
         </div>
       </div>
-    </div>
+    {% else %}
+      <div class="p-strip">
+        <div class="row">
+          <div class="col-6">
+            <h3>Why not try widening your search?</h3>
+            <p>You can do this by:</p>
+            <ul class="p-list">
+              <li class="p-list__item is-ticked">Adding alternative words or phrases</li>
+              <li class="p-list__item is-ticked">Using individual words instead of phrases</li>
+              <li class="p-list__item is-ticked">Trying a different spelling</li>
+            </ul>
+          </div>
+          <div class="col-6">
+            <h3>Still no luck?</h3>
+            <ul class="p-list">
+              <li class="p-list__item is-ticked"><a href="/">Visit the Multipass homepage</a></li>
+              <li class="p-list__item is-ticked"><a href="https://discourse.ubuntu.com/c/multipass/21">Visit the forum</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
     {% endif %}
-  </div>
+  {% endif %}
 {% endblock content %}
-

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -5,6 +5,7 @@ import talisker.requests
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam import image_template
 from canonicalwebteam.discourse import DiscourseAPI, DocParser, Docs
+from canonicalwebteam.search import build_search_view
 
 from flask import render_template, make_response
 
@@ -34,6 +35,16 @@ main_docs = Docs(
     blueprint_name="main_docs",
 )
 main_docs.init_app(app)
+
+app.add_url_rule(
+    "/docs/search",
+    "docs-search",
+    build_search_view(
+        session=session,
+        site="charmed-kubeflow.io/docs",
+        template_path="docs/search.html",
+    ),
+)
 
 init_tutorials(app, "/tutorials")
 


### PR DESCRIPTION
## Done

**Note** it is working when you run it locally, but not in the demo...

- Updates the side-navigation to the latest vanilla pattern
- Implements search for the docs, based on the search for multipass.run

## QA

- Check out https://charmed-kubeflow-io-139.demos.haus/docs
- Check the side-navigation collapses and un-collapses as expected
- Check the search returns some results



## Issue / Card

Fixes https://github.com/canonical/charmed-kubeflow.io/issues/135
https://github.com/canonical/charmed-kubeflow.io/issues/134
