### PR TITLE
fix(bug): set table layout fixed to auto #137

### DIFF
--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -6,3 +6,5 @@ $color-suru-end: #1a1a1a;
 
 $theme-default-nav: dark;
 $color-navigation-active-bar: $color-brand;
+
+$table-layout-fixed: false;


### PR DESCRIPTION
## Done

- updated the table layout setting in SCSS to "auto", rather than the default "fixed"

## QA

- Visit https://charmed-kubeflow-io-142.demos.haus/docs/operators-and-bundles
- See that the table on that page does _not_ have equal column widths (compare to [live](https://charmed-kubeflow.io/docs/operators-and-bundles), where there is a lot more whitespace in the first column)


## Issue / Card

Fixes https://github.com/canonical/charmed-kubeflow.io/issues/137

## Screenshots

Before:
![Screenshot from 2022-12-06 17-06-23](https://user-images.githubusercontent.com/2376968/205976560-79b1e9f2-fbe1-4a1e-acc8-7e1ae9964e24.png)

After:
![image](https://user-images.githubusercontent.com/2376968/205976506-b304cbe5-bd93-44b3-8afe-f43ed101901f.png)

