### PR TITLE
fix(bug): add redirect from /tutorials to /docs

### DIFF
--- a/deleted.yaml
+++ b/deleted.yaml
@@ -1,1 +1,0 @@
-tutorials:

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,0 +1,1 @@
+tutorials/?: /docs


### PR DESCRIPTION
## Done

- Removed deleted.yaml and instead redirect /tutorials to /docs

## QA

- Visit https://charmed-kubeflow-io-145.demos.haus/tutorials
- You should be redirected to https://charmed-kubeflow-io-145.demos.haus/docs
