### PR TITLE
WD-12460 New Documentation Layout

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,16 +17,18 @@ jobs:
           sleep 1 && curl --head --fail --retry-delay 5 --retry 10 --retry-connrefused http://localhost
 
   run-dotrun:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dotrun
-        uses: canonical/install-dotrun@main
+        run: sudo pip3 install dotrun requests==2.31.0
 
       - name: Install dependencies
-        run: dotrun install
+        run: |
+          sudo chmod -R 777 .
+          dotrun install
 
       - name: Build assets
         run: dotrun build

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "postcss": "8.4.21",
     "postcss-cli": "10.1.0",
     "prettier": "2.8.2",
-    "vanilla-framework": "4.11.1",
+    "vanilla-framework": "4.11.0",
     "watch-cli": "0.2.3",
     "webpack": "5.75.0",
     "webpack-cli": "5.0.1"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "postcss": "8.4.21",
     "postcss-cli": "10.1.0",
     "prettier": "2.8.2",
-    "vanilla-framework": "4.11.0",
+    "vanilla-framework": "4.14.0",
     "watch-cli": "0.2.3",
     "webpack": "5.75.0",
     "webpack-cli": "5.0.1"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "postcss": "8.4.21",
     "postcss-cli": "10.1.0",
     "prettier": "2.8.2",
-    "vanilla-framework": "3.15.1",
+    "vanilla-framework": "4.11.1",
     "watch-cli": "0.2.3",
     "webpack": "5.75.0",
     "webpack-cli": "5.0.1"

--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -6,3 +6,4 @@ $color-suru-end: #1a1a1a;
 $theme-default-nav: dark;
 $color-navigation-active-bar: $color-brand;
 $table-layout-fixed: false;
+$l-documentation-sidebar-width: 18rem;

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -82,6 +82,7 @@
             <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />
       </head>
       <body>
+            <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
             {% block body %}
             <!-- Google Tag Manager (noscript) -->
             <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K7QJ3BF"

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -82,6 +82,7 @@
             <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />
       </head>
       <body>
+            {% block body %}
             <!-- Google Tag Manager (noscript) -->
             <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K7QJ3BF"
         height="0"
@@ -104,5 +105,6 @@
                  data-return-url="http://charmed-kubeflow.io/thank-you"
                  data-lp-url=""></div>
             <script src="{{ versioned_static('js/dynamic-contact-form.js') }}"></script>
+            {% endblock body %}
       </body>
 </html>

--- a/templates/docs/base_layout.html
+++ b/templates/docs/base_layout.html
@@ -1,0 +1,61 @@
+{% extends "base_layout.html" %}
+{% block page_class %}docs{% endblock %}
+{% block title %}
+    {% if document %}
+        {{ document.title }}
+    {% else %}
+        Docs
+    {% endif %}
+{% endblock %}
+{% block meta_title %}
+    {% if document %}
+        {{ document.title }}
+    {% else %}
+        Docs
+    {% endif %}
+{% endblock %}
+{% block body %}
+    <div class="l-docs">
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K7QJ3BF"
+        height="0"
+        width="0"
+        style="display: none;
+               visibility: hidden"></iframe></noscript>
+        <!-- End Google Tag Manager (noscript) -->
+        <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
+        <div class="l-docs__header">
+            {% include "partial/_navigation.html" %}
+            <section id="search-docs" class="p-strip--light is-shallow l-docs__header">
+                
+                <div class="l-docs__subgrid">
+                    <form class="l-docs__main p-search-box u-no-margin--bottom" action="/docs/search">
+                        <input type="search"
+                               class="p-search-box__input"
+                               name="q"
+                               {% if query %}value="{{ query }}"{% endif %}
+                               placeholder="Search documentation"
+                               required />
+                        <button type="submit" class="p-search-box__button" alt="search">
+                            <i class="p-icon--search">Search</i>
+                        </button>
+                    </form>
+                </div>
+            </section>
+        </div>
+        {% block content_docs %}
+        {% endblock content_docs %}
+        <div class="l-docs__footer">{% include "partial/_footer.html" %}</div>
+        <div class="u-hide"
+             id="contact-form-container"
+             data-form-location="/includes/contact-us"
+             data-form-id="1337"
+             data-lp-id="2313"
+             data-return-url="http://charmed-kubeflow.io/thank-you"
+             data-lp-url=""></div>
+        <script src="{{ versioned_static('js/dynamic-contact-form.js') }}"></script>
+    </div>
+    <script src="{{ versioned_static('js/prism.js') }}"></script>
+    <script src="{{ versioned_static('js/docs-side-nav.js') }}"></script>
+    <script src="{{ versioned_static('js/build/discourse-rad-parser/discourse-rad-parser.js')}}"></script>
+    <script>drpNs.DiscourseRADParser();</script>
+{% endblock body %}

--- a/templates/docs/base_layout.html
+++ b/templates/docs/base_layout.html
@@ -22,23 +22,25 @@
         style="display: none;
                visibility: hidden"></iframe></noscript>
         <!-- End Google Tag Manager (noscript) -->
-        <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
         <div class="l-docs__header">
             {% include "partial/_navigation.html" %}
             <section id="search-docs" class="p-strip--light is-shallow l-docs__header">
-                
                 <div class="l-docs__subgrid">
-                    <form class="l-docs__main p-search-box u-no-margin--bottom" action="/docs/search">
-                        <input type="search"
-                               class="p-search-box__input"
-                               name="q"
-                               {% if query %}value="{{ query }}"{% endif %}
-                               placeholder="Search documentation"
-                               required />
-                        <button type="submit" class="p-search-box__button" alt="search">
-                            <i class="p-icon--search">Search</i>
-                        </button>
-                    </form>
+                    <div class="l-docs__main">
+                        <div class="u-fixed-width">
+                            <form class="p-search-box u-no-margin--bottom" action="/docs/search">
+                                <input type="search"
+                                       class="p-search-box__input"
+                                       name="q"
+                                       {% if query %}value="{{ query }}"{% endif %}
+                                       placeholder="Search documentation"
+                                       required />
+                                <button type="submit" class="p-search-box__button" alt="search">
+                                    <i class="p-icon--search">Search</i>
+                                </button>
+                            </form>
+                        </div>
+                    </div>
                 </div>
             </section>
         </div>
@@ -55,7 +57,5 @@
         <script src="{{ versioned_static('js/dynamic-contact-form.js') }}"></script>
     </div>
     <script src="{{ versioned_static('js/prism.js') }}"></script>
-    <script src="{{ versioned_static('js/docs-side-nav.js') }}"></script>
-    <script src="{{ versioned_static('js/build/discourse-rad-parser/discourse-rad-parser.js')}}"></script>
-    <script>drpNs.DiscourseRADParser();</script>
+    
 {% endblock body %}

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -1,108 +1,132 @@
-{% extends "base_layout.html" %}
-
+{% extends "docs/base_layout.html" %}
 {% block page_class %}docs{% endblock %}
 {% block content_class %}l-docs-wrapper{% endblock %}
 {% block title %}{{ document.title }} | Documentation{% endblock %}
+{% set is_docs = True %}
 
-{% block content %}
-{% macro create_navigation(nav_items, expandable=False, expanded=False) %}
-  <ul class="p-side-navigation__list">
-    {% for element in nav_items %}
-    <li class="p-side-navigation__item">
-      {% if element.navlink_href %}
-      <a
-        class="p-side-navigation__link {% if expandable and element.children %}is-expandable{% endif %}"
-        href="{{ element.navlink_href }}"
-        {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
-        {% if element.is_active %}aria-current="page"{% endif %}
-      >{{ element.navlink_text }}</a>
-      {% else %}
-        <span
-          class="p-side-navigation__text {% if expandable and element.children %}is-expandable{% endif %}"
-          {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
-          {% if element.is_active %}aria-current="page"{% endif %}
-        >{{ element.navlink_text }}</span>
-      {% endif %}
-
-      {% if expandable %}
-        {% if element.children %}
-            <button class="p-side-navigation__expand" aria-expanded={% if element.is_active or element.has_active_child %}"true"{% else %}"false"{% endif %} aria-label="show submenu for {{ element.navlink_text }}"></button>
-        {% endif %}
-        {{ create_navigation(element.children, expandable, element.is_active or element.has_active_child) }}
-      {% else %}
-        {% if element.children %}
-          {{ create_navigation(element.children, expandable) }}
-        {% endif %}
-      {% endif %}
-    </li>
-    {% endfor %}
-  </ul>
-{% endmacro %}
-
-<section id="search-docs" class="p-strip--light is-shallow">
-  <div class="row">
-    <form class="p-search-box u-no-margin--bottom" action="/docs/search">
-      <input type="search" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search documentation" required/>
-      <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search">Search</i></button>
-    </form>
-  </div>
-</section>
-
-<section class="p-strip u-extra-space">
+{% block content_docs %}
+  {% macro create_navigation(nav_items, expandable=False, expanded=False) %}
+    <ul class="p-side-navigation__list ">
+      {% for element in nav_items %}
+        <li class="p-side-navigation__item">
+          {% if element.navlink_href %}
+            <a class="p-side-navigation__link {% if expandable and element.children %}is-expandable{% endif %}"
+               href="{{ element.navlink_href }}"
+               {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}
+               {% endif %}
+               {% if element.is_active %}aria-current="page"{% endif %}>{{ element.navlink_text }}</a>
+          {% else %}
+            <span class="p-side-navigation__text {% if expandable and element.children %}is-expandable{% endif %}"
+                  {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}
+                  {% endif %}
+                  {% if element.is_active %}aria-current="page"{% endif %}>{{ element.navlink_text }}</span>
+          {% endif %}
+          {% if expandable %}
+            {% if element.children %}
+              <button class="p-side-navigation__expand"
+                      aria-expanded="{% if element.is_active or element.has_active_child %}" " true " {% else %} " false " {% endif %} aria-label="
+                      show
+                      submenu
+                      for
+                      {{ element.navlink_text }}
+                      "></button>
+            {% endif %}
+            {{ create_navigation(element.children, expandable, element.is_active or element.has_active_child) }}
+          {% else %}
+            {% if element.children %}{{ create_navigation(element.children, expandable) }}{% endif %}
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  {% endmacro %}
   {% if schedule_banner("2023-03-08", "2023-03-22") %}
     {% include "partial/_beta-banner.html" %}
   {% endif %}
-  <div class="row">
-    <aside class="col-3">
+  <div class="l-docs__sidebar ">
+    <div class="l-docs__sticky-container">
       {% if versions | length > 1 %}
-      <label for="version-select" class="u-hide">Version</label>
-      <select name="version-select" id="version-select" onChange="window.location.href=this.value">
-      {% for version in versions %}
-        {% set active = docs_version == version['path'] %}
-        <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>Version {{ version['version'] }}</option>
-      {% endfor %}
-      <select>
+        <label for="version-select" class="u-hide">Version</label>
+        <select name="version-select"
+                id="version-select"
+                onChange="window.location.href=this.value">
+          {% for version in versions %}
+            {% set active = docs_version == version['path'] %}
+            <option value="{{ version_paths[version['path']] }}"
+                    {% if active %}selected{% endif %}>Version {{ version['version'] }}</option>
+          {% endfor %}
+        </select>
       {% endif %}
-
-      <nav data-js="navigation" class="p-side-navigation" id="{{ navigation['path'] or 'default' }}">
-        <a href="#{{ navigation['path'] or 'default' }}" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="{{ navigation['path'] or 'default' }}">
-          Toggle side navigation
-        </a>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="{{ navigation['path'] or 'default' }}"></div>
+      <nav data-js="navigation"
+           class="p-side-navigation"
+           id="{{ navigation['path'] or 'default' }}">
+        <a href="#{{ navigation['path'] or 'default' }}"
+           class="p-side-navigation__toggle js-drawer-toggle"
+           aria-controls="{{ navigation['path'] or 'default' }}">Toggle side navigation</a>
+        <div class="p-side-navigation__overlay js-drawer-toggle"
+             aria-controls="{{ navigation['path'] or 'default' }}"></div>
         <div class="p-side-navigation__drawer">
           <div class="p-side-navigation__drawer-header">
-            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="{{ navigation['path'] or 'default' }}">
-              Toggle side navigation
-            </a>
+            <a href="#"
+               class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
+               aria-controls="{{ navigation['path'] or 'default' }}">Toggle side navigation</a>
           </div>
           {% for nav_group in navigation.nav_items %}
-          {% if not nav_group.hidden %}
-            {% if nav_group.navlink_text %}
-              {% if nav_group.navlink_href %}
-                <h3 class="p-side-navigation__heading--linked">
-                  <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active %}aria-current="page"{% endif %}>
-                    {{ nav_group.navlink_text }}
-                  </a>
-                </h3>
-              {% else %}
-                <h3 class="p-side-navigation__heading">{{ nav_group.navlink_text }}</h3>
+            {% if not nav_group.hidden %}
+              {% if nav_group.navlink_text %}
+                {% if nav_group.navlink_href %}
+                  <h3 class="p-side-navigation__heading--linked">
+                    <a class="p-side-navigation__link"
+                       href="{{ nav_group.navlink_href }}"
+                       {% if nav_group.is_active %}aria-current="page"{% endif %}>{{ nav_group.navlink_text }}</a>
+                  </h3>
+                {% else %}
+                  <h3 class="p-side-navigation__heading">{{ nav_group.navlink_text }}</h3>
+                {% endif %}
               {% endif %}
-            {% endif %}
-            {#
+              {#
               Use `create_navigation(nav_group.children)` for a default, fully expanded navigation.
               Use `create_navigation(nav_group.children, expandable=True)` for the nested nav levels to expand only when parent page is active.
             #}
-            {{ create_navigation(nav_group.children, expandable=True) }}
-          {% endif %}
+              {{ create_navigation(nav_group.children, expandable=True) }}
+            {% endif %}
           {% endfor %}
         </div>
       </nav>
-    </aside>
-    <main class="col-9" id="main-content">
+    </div>
+  </div>
+  <div class="l-docs__title">
+    <div class="u-fixed-width">
       <h1>{{ document.title }}</h1>
+    </div>
+  </div>
+  {% if document.headings_map is defined and document.headings_map|length > 0 %}
+    <div class="l-docs__meta">
+      <div class="l-docs__sticky-container">
+        <aside class="p-table-of-contents">
+          <div class="p-table-of-contents__section">
+            <h4 class="p-table-of-contents__header">On this page</h4>
+            <nav class="p-table-of-contents__nav" aria-label="Table of contents">
+              <ul class="p-table-of-contents__list">
+                {% for heading in document.headings_map %}
+                  <li class="p-table-of-contents__item">
+                    <a class="p-table-of-contents__link" href="#{{ heading.heading_slug }}">{{ heading.heading_text }}</a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </nav>
+          </div>
+        </aside>
+      </div>
+    </div>
+  {% endif %}
+  <!-- {{ document }} -->
+  <div class="l-docs__main">
+    <main id="main-content u-fixed-width">
       {{ document.body_html | safe }}
       <hr />
-      <p><i>Last updated {{ document.updated }}.</i></p>
+      <p>
+        <i>Last updated {{ document.updated }}.</i>
+      </p>
       <div class="p-notification--information">
         <p class="p-notification__content">
           <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
@@ -110,9 +134,7 @@
       </div>
     </main>
   </div>
-</section>
-
-<script src="{{ versioned_static('js/prism.js') }}"></script>
-<script src="{{ versioned_static('js/side-navigation.js') }}"></script>
-
-{% endblock %}
+  <script src="{{ versioned_static('js/prism.js') }}"></script>
+  <script src="{{ versioned_static('js/side-navigation.js') }}"></script>
+  <script src="{{ versioned_static('js/docs-side-nav.js') }}"></script>
+{% endblock content_docs %}

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -3,7 +3,6 @@
 {% block content_class %}l-docs-wrapper{% endblock %}
 {% block title %}{{ document.title }} | Documentation{% endblock %}
 {% set is_docs = True %}
-
 {% block content_docs %}
   {% macro create_navigation(nav_items, expandable=False, expanded=False) %}
     <ul class="p-side-navigation__list ">
@@ -24,7 +23,7 @@
           {% if expandable %}
             {% if element.children %}
               <button class="p-side-navigation__expand"
-                      aria-expanded="{% if element.is_active or element.has_active_child %}" " true " {% else %} " false " {% endif %} aria-label="
+                      aria-expanded={% if element.is_active or element.has_active_child %}"true"{% else %}"false"{% endif %} aria-label="
                       show
                       submenu
                       for
@@ -120,8 +119,8 @@
     </div>
   {% endif %}
   <!-- {{ document }} -->
-  <div class="l-docs__main">
-    <main id="main-content u-fixed-width">
+  <div class="l-docs__main u-fixed-width">
+    <main id="main-content">
       {{ document.body_html | safe }}
       <hr />
       <p>
@@ -136,5 +135,4 @@
   </div>
   <script src="{{ versioned_static('js/prism.js') }}"></script>
   <script src="{{ versioned_static('js/side-navigation.js') }}"></script>
-  <script src="{{ versioned_static('js/docs-side-nav.js') }}"></script>
 {% endblock content_docs %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -258,7 +258,7 @@
     </section>
     <section class="p-strip">
       <div class="row">
-        <div class="col-4 u-hide--small u-hide--medium ">
+        <div class="col-4 u-hide--small u-hide--medium u-vertically-align">
           <div class="p-logo-section">
             <div class="p-logo-section__items">
               <div class="p-logo-section__item">

--- a/templates/index.html
+++ b/templates/index.html
@@ -228,230 +228,260 @@
           </ul>
         </div>
         <div class="col-5 u-vertically-center p-logo-section">
-          <div class="p-logo-section__items" style="margin: .5rem">
-            <div class="p-logo-section__item" style="margin: 1.875rem">
-              {{ image(url="https://assets.ubuntu.com/v1/5ecd8306-Apache_Spark_logo.svg",
-                            alt="Apache Spark",
-                            width="148",
-                            height="78",
-                            hi_def=True,
-                            attrs={"class": "p-logo-section__logo"},) | safe
+          <div class="p-logo-section__items">
+            <div class="p-logo-section__item">
+              {{ image (
+              url="https://assets.ubuntu.com/v1/a8fbddc8-apache-spark-logo.png",
+              alt="",
+              width="150",
+              height="189",
+              hi_def=True,
+              loading="auto|lazy"
+              ) | safe
               }}
             </div>
-            <div class="p-logo-section__item" style="margin: 1.875rem">
-              {{ image(url="https://assets.ubuntu.com/v1/c2a4ebd4-Kafka.svg",
-                            alt="Kafka",
-                            width="147",
-                            height="68",
-                            hi_def=True,
-                            attrs={"class": "p-logo-section__logo"},) | safe
+            <div class="p-logo-section__item">
+              {{ image (
+              url="https://assets.ubuntu.com/v1/9899746b-kafka-logo.png",
+              alt="",
+              width="150",
+              height="205",
+              hi_def=True,
+              loading="auto|lazy"
+              ) | safe
               }}
             </div>
           </div>
         </div>
-      </section>
-      <section class="p-strip">
-        <div class="row">
-          <div class="col-4 u-hide--small u-hide--medium ">
-            <div class="p-logo-section">
-              <div class="p-logo-section__items">
-                <div class="p-logo-section__item">
-                  <img class="p-logo-section__logo"
-                       src="https://assets.ubuntu.com/v1/8e871a40-MLflow-Logo.svg"
-                       style="width: 12rem" />
-                </div>
-                <div class="p-logo-section__item">
-                  <img class="p-logo-section__logo"
-                       src="https://assets.ubuntu.com/v1/e227c0b2-seldon.d08abf3e.png"
-                       style="width: 12rem;
-                              margin-top: 0.8rem;
-                              margin-bottom: 1.6rem" />
-                </div>
-                <div class="p-logo-section__item">
-                  <img class="p-logo-section__logo"
-                       src="https://assets.ubuntu.com/v1/5ecd8306-Apache_Spark_logo.svg"
-                       style="width: 12rem" />
-                </div>
+      </div>
+    </section>
+    <section class="p-strip">
+      <div class="row">
+        <div class="col-4 u-hide--small u-hide--medium ">
+          <div class="p-logo-section">
+            <div class="p-logo-section__items">
+              <div class="p-logo-section__item">
+                <img class="p-logo-section__logo"
+                     src="https://assets.ubuntu.com/v1/8e871a40-MLflow-Logo.svg"
+                     style="width: 12rem" />
               </div>
-            </div>
-          </div>
-          <div class="col-8">
-            <h2>Open source data operations</h2>
-            <p class="p-heading--4 u-sv2">Composable, model-driven solutions</p>
-            <p>
-              Make use of open source integration code and compound the benefit of <a href="https://charmhub.io/">300+ available Juju charm operators</a>.
-            </p>
-            <p>
-              The Juju charm operator solution from Canonical makes deploying and managing Charmed Kubeflow predictable, repeatable and reliable for your IT operations team. Zero friction, from proof-of-concept to production.
-            </p>
-            <p>
-              Engineered for flexibility around complex scenarios, the Juju charms extended ecosystem allows you to tailor Charmed Kubeflow to your needs with additional integrations &mdash; like MLFlow, Apache Spark and Seldon Core.
-            </p>
-            <p>
-              <a href="https://jaas.ai/kubeflow/bundle" class="p-button--neurtal">Kubeflow charms and models&nbsp;&rsaquo;</a>
-            </p>
-          </div>
-        </div>
-      </section>
-      <section class="p-strip--light">
-        <div class="row">
-          <div class="col-7">
-            <h2>Optimised for every cloud</h2>
-            <p class="p-heading--4 u-sv2">Fast AI predictions on every major cloud with GPU acceleration</p>
-            <p>We work with Amazon AWS, Microsoft Azure, Google and Oracle clouds to simplify multi-cloud, GPU accelerated AI.</p>
-            <p>
-              Easy setup across cloud Kubernetes services for a multi-cloud MLOps platform. Get the elasticity of the public clouds with the governance of on-premise service management. Separate training from production environments as required &mdash; hybrid cloud is also supported.
-            </p>
-            <p>
-              Automated deployment and management with Canonical's Juju charm model-driven operator solution. Support for major cloud Kubernetes services including Azure AKS, AWS EKS and Google GKE.
-            </p>
-            <p>
-              <a href="https://ubuntu.com/kubernetes">Kubeflow on multi-cloud K8s&nbsp;&rsaquo;</a>
-            </p>
-          </div>
-          <div class="col-5 u-hide--small u-hide--medium ">
-            <div class="p-logo-section">
-              <div class="p-logo-section__items">
-                <div class="p-logo-section__item">
-                  <img class="p-logo-section__logo"
-                       src="https://assets.ubuntu.com/v1/e7a3c4d8-MicrosoftAzure.svg"
-                       style="height: 3rem; margin: 2rem;" />
-                </div>
-                <div class="p-logo-section__item">
-                  <img class="p-logo-section__logo"
-                       src="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg"
-                       style="height: 3rem; margin: 2rem;" />
-                </div>
-                <div class="p-logo-section__item">
-                  <img class="p-logo-section__logo"
-                       src="https://assets.ubuntu.com/v1/6e176d9a-Google+Cloud+stacked.svg"
-                       style="height: 3rem; margin: 2rem;" />
-                </div>
-                <div class="p-logo-section__item">
-                  <img class="p-logo-section__logo"
-                       src="https://assets.ubuntu.com/v1/cb2c8b1f-Oracle.svg"
-                       style="height: 3rem; margin: 2rem;" />
-                </div>
+              <div class="p-logo-section__item">
+                <img class="p-logo-section__logo"
+                     src="https://assets.ubuntu.com/v1/e227c0b2-seldon.d08abf3e.png"
+                     style="width: 12rem;
+                            margin-top: 0.8rem;
+                            margin-bottom: 1.6rem" />
+              </div>
+              <div class="p-logo-section__item">
+                <img class="p-logo-section__logo"
+                     src="https://assets.ubuntu.com/v1/5ecd8306-Apache_Spark_logo.svg"
+                     style="width: 12rem" />
               </div>
             </div>
           </div>
         </div>
-      </section>
-      <section class="p-strip">
-        <div class="row">
-          <div class="col-6 u-vertically-center u-hide--small u-hide--medium p-logo-section">
-            <div class="p-logo-section">
-              <div class="p-logo-section__items">
-                <div class="p-logo-section__item" style="margin: 1.875rem">
-                  {{ image(url="https://assets.ubuntu.com/v1/97e29c13-Dell.svg",
-                                    alt="Dell",
-                                    width="60",
-                                    height="60",
-                                    hi_def=True,
-                                    attrs={"class": "p-logo-section__logo"},) | safe
-                  }}
-                </div>
-                <div class="p-logo-section__item" style="margin: 1.875rem">
-                  {{ image(url="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg",
-                                    alt="NVIDIA",
-                                    width="60",
-                                    height="50",
-                                    hi_def=True,
-                                    attrs={"class": "p-logo-section__logo"},) | safe
-                  }}
-                </div>
-                <div class="p-logo-section__item" style="margin: 1.875rem">
-                  {{ image(url="https://assets.ubuntu.com/v1/182d5546-logo-hp.png",
-                                    alt="HP",
-                                    width="60",
-                                    height="60",
-                                    hi_def=True,
-                                    attrs={"class": "p-logo-section__logo"},) | safe
-                  }}
-                </div>
-                <div class="p-logo-section__item" style="margin: 1.875rem">
-                  {{ image(url="https://assets.ubuntu.com/v1/7c91270a-Lenovo.svg",
-                                    alt="Lenovo",
-                                    width="165",
-                                    height="35",
-                                    hi_def=True,
-                                    attrs={"class": "p-logo-section__logo"},) | safe
-                  }}
-                </div>
+        <div class="col-8">
+          <h2>Open source data operations</h2>
+          <p class="p-heading--4 u-sv2">Composable, model-driven solutions</p>
+          <p>
+            Make use of open source integration code and compound the benefit of <a href="https://charmhub.io/">300+ available Juju charm operators</a>.
+          </p>
+          <p>
+            The Juju charm operator solution from Canonical makes deploying and managing Charmed Kubeflow predictable, repeatable and reliable for your IT operations team. Zero friction, from proof-of-concept to production.
+          </p>
+          <p>
+            Engineered for flexibility around complex scenarios, the Juju charms extended ecosystem allows you to tailor Charmed Kubeflow to your needs with additional integrations &mdash; like MLFlow, Apache Spark and Seldon Core.
+          </p>
+          <p>
+            <a href="https://jaas.ai/kubeflow/bundle" class="p-button--neurtal">Kubeflow charms and models&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section class="p-strip--light">
+      <div class="row">
+        <div class="col-7">
+          <h2>Optimised for every cloud</h2>
+          <p class="p-heading--4 u-sv2">Fast AI predictions on every major cloud with GPU acceleration</p>
+          <p>We work with Amazon AWS, Microsoft Azure, Google and Oracle clouds to simplify multi-cloud, GPU accelerated AI.</p>
+          <p>
+            Easy setup across cloud Kubernetes services for a multi-cloud MLOps platform. Get the elasticity of the public clouds with the governance of on-premise service management. Separate training from production environments as required &mdash; hybrid cloud is also supported.
+          </p>
+          <p>
+            Automated deployment and management with Canonical's Juju charm model-driven operator solution. Support for major cloud Kubernetes services including Azure AKS, AWS EKS and Google GKE.
+          </p>
+          <p>
+            <a href="https://ubuntu.com/kubernetes">Kubeflow on multi-cloud K8s&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+        <div class="col-5 u-hide--small u-hide--medium ">
+          <div class="p-logo-section">
+            <div class="p-logo-section__items">
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/1b8e4451-aws-logo.png",
+                                alt="AWS",
+                                width="124",
+                                height="257",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/d2a1dea3-microsoft-azure-2021.png",
+                                alt="Azure",
+                                width="79",
+                                height="257",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/fc0bb593-google-cloud-logo.png",
+                                alt="Google Cloud",
+                                width="397",
+                                height="257",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/7267b565-oracle-new-logo.png",
+                                alt="Oracle",
+                                width="369",
+                                height="368",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
+                }}
               </div>
             </div>
           </div>
-          <div class="col-6">
-            <h2>Full-stack Charmed Kubeflow</h2>
-            <p class="p-heading--4 u-sv2">Get your AI initiative up and running fast with integrated, proven solutions.</p>
-            <p>
-              We work with system vendors like Dell, Lenovo, HP and NVIDIA to bring the best out-of-the-box MLOps experience to the data centre.
-            </p>
-            <p>
-              Operate a bare-metal Kubernetes cloud on-premise with <a href="http://maas.io">Metal As A Service</a>.
-            </p>
-            <p>
-              Canonical's Juju charm model-driven operator solution for Charmed Kubeflow delivers a horizontally scalable, integrated data science system for AI. Includes Canonical Observability Stack, Ceph storage system, Charmed Kubernetes and the Charmed Kubeflow MLOps platform. All with full, 24/7 support available from Canonical.
-            </p>
-            <ul class="p-inline-list">
-              <li class="p-inline-list__item">
-                <a href="https://lenovopress.com/lp1415-canonical-charmed-kubernetes-on-thinksystem-for-ai-development">Lenovo AI Development Reference Architecture</a>
-              </li>
-            </ul>
-            <ul class="p-inline-list">
-              <li class="p-inline-list__item">
-                <a href="https://ubuntu.com/engage/dell-kubeflow-reference-architecture">Dell and Canonical Reference Architecture</a>
-              </li>
-              <li class="p-inline-list__item">
-                <a href="/contact-us" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a>
-              </li>
-            </ul>
+        </div>
+      </div>
+    </section>
+    <section class="p-strip">
+      <div class="row">
+        <div class="col-6 u-vertically-center u-hide--small u-hide--medium p-logo-section">
+          <div class="p-logo-section">
+            <div class="p-logo-section__items">
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/25d7b284-hp-logo%20.png",
+                                alt="HP",
+                                width="195",
+                                height="474",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/c98e92ee-dell-logo%20.png",
+                                alt="Dell",
+                                width="231",
+                                height="474",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/2cbbaaf5-lenovo-logo%20.png",
+                                alt="Lenovo",
+                                width="318",
+                                height="474",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image (
+                url="https://assets.ubuntu.com/v1/e86f8702-nvidia-logo%20.png",
+                alt="",
+                width="200",
+                height="200",
+                hi_def=True,
+                loading="auto|lazy"
+                ) | safe
+                }}
+              </div>
+            </div>
           </div>
         </div>
-      </section>
-      <section class="p-strip--light">
-        <div class="row">
-          <div class="col-7">
-            <h2>The MLOps on Kubernetes experts</h2>
-            <p>
-              Charmed Kubeflow is complemented by other Kubernetes solutions available from Canonical, including MicroK8s and Charmed Kubernetes.
-            </p>
-            <p>
-              <a href="http://microk8s.io">MicroK8s</a> is the tiny yet mighty, opinionated zero-ops Kubernetes distribution. Easily build a distributed MLOps environment in record time.
-            </p>
-            <p>
-              <a href="https://ubuntu.com/kubernetes/install#cluster">Charmed Kubernetes</a> delivers full flexibility and comprehensive control. Deliver a world-class data science cluster at epic scale.
-            </p>
-          </div>
-          <div class="col-3 u-align--center u-vertically-center">
-            {{ image(url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
-                        alt="",
-                        width="480",
-                        height="65",
-                        hi_def=True,) | safe
-            }}
-          </div>
+        <div class="col-6">
+          <h2>Full-stack Charmed Kubeflow</h2>
+          <p class="p-heading--4 u-sv2">Get your AI initiative up and running fast with integrated, proven solutions.</p>
+          <p>
+            We work with system vendors like Dell, Lenovo, HP and NVIDIA to bring the best out-of-the-box MLOps experience to the data centre.
+          </p>
+          <p>
+            Operate a bare-metal Kubernetes cloud on-premise with <a href="http://maas.io">Metal As A Service</a>.
+          </p>
+          <p>
+            Canonical's Juju charm model-driven operator solution for Charmed Kubeflow delivers a horizontally scalable, integrated data science system for AI. Includes Canonical Observability Stack, Ceph storage system, Charmed Kubernetes and the Charmed Kubeflow MLOps platform. All with full, 24/7 support available from Canonical.
+          </p>
+          <ul class="p-inline-list">
+            <li class="p-inline-list__item">
+              <a href="https://lenovopress.com/lp1415-canonical-charmed-kubernetes-on-thinksystem-for-ai-development">Lenovo AI Development Reference Architecture</a>
+            </li>
+          </ul>
+          <ul class="p-inline-list">
+            <li class="p-inline-list__item">
+              <a href="https://ubuntu.com/engage/dell-kubeflow-reference-architecture">Dell and Canonical Reference Architecture</a>
+            </li>
+            <li class="p-inline-list__item">
+              <a href="/contact-us" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a>
+            </li>
+          </ul>
         </div>
-      </section>
-      <section class="p-strip">
-        <div class="row u-equal-height">
-          <div class="col-3 col-start-large-2 u-align--center u-hide--small u-hide--medium u-vertically-center">
-            {{ image(url="https://assets.ubuntu.com/v1/24a03775-Contact+us.svg",
-                        alt="",
-                        width="240",
-                        height="171",
-                        hi_def=True,) | safe
-            }}
-          </div>
-          <div class="col-7 col-start-large-6">
-            <h3>Need help?</h3>
-            <p>
-              Get in touch with one of our experts now to find out more about Canonical's 24/7 expert services for MLOps environments running Charmed Kubeflow.
-            </p>
-            <p>
-              <a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
-            </p>
-          </div>
+      </div>
+    </section>
+    <section class="p-strip--light">
+      <div class="row">
+        <div class="col-7">
+          <h2>The MLOps on Kubernetes experts</h2>
+          <p>
+            Charmed Kubeflow is complemented by other Kubernetes solutions available from Canonical, including MicroK8s and Charmed Kubernetes.
+          </p>
+          <p>
+            <a href="http://microk8s.io">MicroK8s</a> is the tiny yet mighty, opinionated zero-ops Kubernetes distribution. Easily build a distributed MLOps environment in record time.
+          </p>
+          <p>
+            <a href="https://ubuntu.com/kubernetes/install#cluster">Charmed Kubernetes</a> delivers full flexibility and comprehensive control. Deliver a world-class data science cluster at epic scale.
+          </p>
         </div>
-      </section>
-    {% endblock %}
+        <div class="col-3 u-align--center u-vertically-center">
+          {{ image(url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
+                    alt="",
+                    width="480",
+                    height="65",
+                    hi_def=True,) | safe
+          }}
+        </div>
+      </div>
+    </section>
+    <section class="p-strip">
+      <div class="row u-equal-height">
+        <div class="col-3 col-start-large-2 u-align--center u-hide--small u-hide--medium u-vertically-center">
+          {{ image(url="https://assets.ubuntu.com/v1/24a03775-Contact+us.svg",
+                    alt="",
+                    width="240",
+                    height="171",
+                    hi_def=True,) | safe
+          }}
+        </div>
+        <div class="col-7 col-start-large-6">
+          <h3>Need help?</h3>
+          <p>
+            Get in touch with one of our experts now to find out more about Canonical's 24/7 expert services for MLOps environments running Charmed Kubeflow.
+          </p>
+          <p>
+            <a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+          </p>
+        </div>
+      </div>
+    </section>
+  {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,9 +5,6 @@
 {% endblock meta_description %}
 {% block content %}
   <section class="p-strip--suru">
-    {% if schedule_banner("2023-03-08", "2023-03-22") %}
-      {% include "partial/_beta-banner.html" %}
-    {% endif %}
     <div class="row u-equal-height">
       <div class="col-6 u-vertically-center">
         <div>
@@ -125,6 +122,8 @@
                 alt="",
                 width="324",
                 height="302",
+                attrs={"class": "p-logo-section__logo"},
+                loading="lazy",
                 hi_def=True,) | safe
         }}
       </div>
@@ -136,6 +135,8 @@
                     alt="",
                     width="279",
                     height="300",
+                    attrs={"class": "p-logo-section__logo"},
+                    loading="lazy",
                     hi_def=True,) | safe
           }}
         </div>
@@ -261,21 +262,40 @@
           <div class="p-logo-section">
             <div class="p-logo-section__items">
               <div class="p-logo-section__item">
-                <img class="p-logo-section__logo"
-                     src="https://assets.ubuntu.com/v1/8e871a40-MLflow-Logo.svg"
-                     style="width: 12rem" />
+                {{ image (
+                url="https://assets.ubuntu.com/v1/24b77e42-mlflow-logo.png",
+                alt="",
+                width="222",
+                height="312",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+                ) | safe
+                }}
               </div>
               <div class="p-logo-section__item">
-                <img class="p-logo-section__logo"
-                     src="https://assets.ubuntu.com/v1/e227c0b2-seldon.d08abf3e.png"
-                     style="width: 12rem;
-                            margin-top: 0.8rem;
-                            margin-bottom: 1.6rem" />
+                {{ image (
+                url="https://assets.ubuntu.com/v1/d51c2128-seldon-logo.png",
+                alt="",
+                width="304",
+                height="312",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+                ) | safe
+                }}
               </div>
               <div class="p-logo-section__item">
-                <img class="p-logo-section__logo"
-                     src="https://assets.ubuntu.com/v1/5ecd8306-Apache_Spark_logo.svg"
-                     style="width: 12rem" />
+                {{ image (
+                url="https://assets.ubuntu.com/v1/a8fbddc8-apache-spark-logo.png",
+                alt="",
+                width="241",
+                height="312",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+                ) | safe
+                }}
               </div>
             </div>
           </div>
@@ -314,7 +334,7 @@
             <a href="https://ubuntu.com/kubernetes">Kubeflow on multi-cloud K8s&nbsp;&rsaquo;</a>
           </p>
         </div>
-        <div class="col-5 u-hide--small u-hide--medium ">
+        <div class="col-5 u-hide--small u-hide--medium u-align--center u-vertically-center">
           <div class="p-logo-section">
             <div class="p-logo-section__items">
               <div class="p-logo-section__item">
@@ -404,7 +424,8 @@
                 width="200",
                 height="200",
                 hi_def=True,
-                loading="auto|lazy"
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
                 ) | safe
                 }}
               </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,481 +1,457 @@
 {% extends 'base_layout.html' %}
 {% block title %}Kubeflow AI and MLOps at any scale{% endblock %}
-{% block meta_description %}Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud.{% endblock meta_description%}
-
+{% block meta_description %}
+  Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud.
+{% endblock meta_description %}
 {% block content %}
-<section class="p-strip--suru">
-  {% if schedule_banner("2023-03-08", "2023-03-22") %}
-    {% include "partial/_beta-banner.html" %}
-  {% endif %}
-  <div class="row u-equal-height">
-    <div class="col-6 u-vertically-center">
-      <div>
-        <h1>Kubeflow AI and MLOps at any scale</h1>
-        <p class="p-heading--4">Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud.</p>
-        <p>A complete solution for sophisticated data science labs. Upgrades and security updates &mdash; all supported in the free, open source distribution.</p>
+  <section class="p-strip--suru">
+    {% if schedule_banner("2023-03-08", "2023-03-22") %}
+      {% include "partial/_beta-banner.html" %}
+    {% endif %}
+    <div class="row u-equal-height">
+      <div class="col-6 u-vertically-center">
+        <div>
+          <h1>Kubeflow AI and MLOps at any scale</h1>
+          <p class="p-heading--4">Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud.</p>
+          <p>
+            A complete solution for sophisticated data science labs. Upgrades and security updates &mdash; all supported in the free, open source distribution.
+          </p>
+          <p>
+            <a href="/contact-us" class="js-invoke-modal p-button--positive">Contact us now</a>
+            <a href="https://ubuntu.com/engage/mlops-guide" class="p-button">Read our guide to MLOps</a>
+          </p>
+        </div>
+      </div>
+      <div class="col-6 u-align--center u-hide--small u-hide--medium">
+        {{ image(url="https://assets.ubuntu.com/v1/10400c98-Charmed-kubeflow-Topology-header.svg",
+                alt="",
+                width="350",
+                height="312",
+                loading="eager",
+                hi_def=True,) | safe
+        }}
+      </div>
+    </div>
+  </section>
+  <section class="p-strip">
+    <div class="row">
+      <div class="col-3">
+        <p class="p-heading--3">Accelerate MLOps</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">One solution, any cloud</li>
+          <li class="p-list__item is-ticked">Multi-user collaboration</li>
+          <li class="p-list__item is-ticked">Parallel training at any scale</li>
+          <li class="p-list__item is-ticked">TensorFlow, MXNet, PyTorch and more</li>
+        </ul>
+      </div>
+      <div class="col-3">
+        <p class="p-heading--3">Cloud ready</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">GPU acceleration</li>
+          <li class="p-list__item is-ticked">Ready to run on Amazon EKS</li>
+          <li class="p-list__item is-ticked">Ready to run on Microsoft Azure AKS</li>
+        </ul>
+      </div>
+      <div class="col-3">
+        <p class="p-heading--3">Servers and VMs</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Runs on Kubernetes</li>
+          <li class="p-list__item is-ticked">Bare metal deployment</li>
+          <li class="p-list__item is-ticked">VM deployment</li>
+          <li class="p-list__item is-ticked">NVIDIA GPU autoconfig</li>
+        </ul>
+      </div>
+      <div class="col-3">
+        <p class="p-heading--3">No restrictions</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Free to use in any environment</li>
+          <li class="p-list__item is-ticked">Open source software</li>
+          <li class="p-list__item is-ticked">24/7 support available</li>
+          <li class="p-list__item is-ticked">Expert services to help get you up and running</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+  <section class="p-strip--light">
+    <div class="row u-equal-height">
+      <div class="col-5 u-align--center u-hide--small u-hide--medium u-vertically-center">
+        {{ image(url="https://assets.ubuntu.com/v1/4028fd74-kubeflow+ai-h.svg",
+                alt="",
+                width="425",
+                height="161",
+                hi_def=True,) | safe
+        }}
+      </div>
+      <div class="col-7">
+        <h2>The complete MLOps lifecycle from concept to production</h2>
+        <p class="p-heading--4 u-sv2">Professionalise data science with automated AI/ML model training pipelines</p>
         <p>
-          <a href="/contact-us" class="js-invoke-modal p-button--positive">Contact us now</a>
-          <a href="https://ubuntu.com/engage/mlops-guide" class="p-button">Read our guide to MLOps</a>
+          Get up and running fast with Charmed Kubeflow on <a href="https://microk8s.io/">MicroK8s</a>, from lab to large scale. Highly available with 3+ nodes.
         </p>
+        <p>
+          Or deploy on Azure, Amazon AWS and Google cloud Kubernetes services with full support available from Canonical &mdash; the experts behind Charmed Kubeflow.
+        </p>
+        <p>
+          Unleash your data scientists with the latest ML tools in a single, browser-based platform. Use the familiar tools they already know &mdash; like Jupyterlab, R, TensorFlow, PyTorch and MXNet.
+        </p>
+        <p>
+          Automatically detect and correct model drift with <a href="https://ubuntu.com/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-1">Kubeflow pipelines</a>.
+        </p>
+        <ul class="p-inline-list">
+          <li class="p-inline-list__item">
+            <a href="/docs/get-started-with-charmed-kubeflow"
+               class="p-button--positive">Get started with Charmed Kubeflow</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="https://ubuntu.com/kubeflow/what-is-kubeflow">What is Kubeflow?</a>
+          </li>
+        </ul>
       </div>
     </div>
-    <div class="col-6 u-align--center u-hide--small u-hide--medium">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/10400c98-Charmed-kubeflow-Topology-header.svg",
-          alt="",
-          width="350",
-          height="312",
-          loading="eager",
-          hi_def=True,
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row">
-    <div class="col-3">
-      <p class="p-heading--3">Accelerate MLOps</p>
-      <ul class="p-list--divided">
-        <li class="p-list__item is-ticked">One solution, any cloud</li>
-        <li class="p-list__item is-ticked">Multi-user collaboration</li>
-        <li class="p-list__item is-ticked">Parallel training at any scale</li>
-        <li class="p-list__item is-ticked">TensorFlow, MXNet, PyTorch and more</li>
-      </ul>
-    </div>
-    <div class="col-3">
-      <p class="p-heading--3">Cloud ready</p>
-      <ul class="p-list--divided">
-        <li class="p-list__item is-ticked">GPU acceleration</li>
-        <li class="p-list__item is-ticked">Ready to run on Amazon EKS</li>
-        <li class="p-list__item is-ticked">Ready to run on Microsoft Azure AKS</li>
-      </ul>
-    </div>
-    <div class="col-3">
-      <p class="p-heading--3">Servers and VMs</p>
-      <ul class="p-list--divided">
-        <li class="p-list__item is-ticked">Runs on Kubernetes</li>
-        <li class="p-list__item is-ticked">Bare metal deployment</li>
-	      <li class="p-list__item is-ticked">VM deployment</li>
-        <li class="p-list__item is-ticked">NVIDIA GPU autoconfig</li>
-      </ul>
-    </div>
-    <div class="col-3">
-      <p class="p-heading--3">No restrictions</p>
-      <ul class="p-list--divided">
-        <li class="p-list__item is-ticked">Free to use in any environment</li>
-        <li class="p-list__item is-ticked">Open source software</li>
-        <li class="p-list__item is-ticked">24/7 support available</li>
-	      <li class="p-list__item is-ticked">Expert services to help get you up and running</li>
-      </ul>
-    </div>
-  </div>
- </section>
-
- <section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-5 u-align--center u-hide--small u-hide--medium u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/4028fd74-kubeflow+ai-h.svg",
-          alt="",
-          width="425",
-          height="161",
-          hi_def=True,
-        ) | safe
-      }}
-    </div>
-    <div class="col-7">
-      <h2>The complete MLOps lifecycle from concept to production</h2>
-      <p class="p-heading--4 u-sv2">Professionalise data science with automated AI/ML model training pipelines</p>
-      <p>Get up and running fast with Charmed Kubeflow on <a href="https://microk8s.io/">MicroK8s</a>, from lab to large scale. Highly available with 3+ nodes.</p>
-      <p>Or deploy on Azure, Amazon AWS and Google cloud Kubernetes services with full support available from Canonical &mdash; the experts behind Charmed Kubeflow.</p>
-      <p>Unleash your data scientists with the latest ML tools in a single, browser-based platform. Use the familiar tools they already know &mdash; like Jupyterlab, R, TensorFlow, PyTorch and MXNet.</p>
-      <p>Automatically detect and correct model drift with <a href="https://ubuntu.com/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-1">Kubeflow pipelines</a>.</p>
-      <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a href="/docs/get-started-with-charmed-kubeflow" class="p-button--positive">Get started with Charmed Kubeflow</a></li>
-        <li class="p-inline-list__item"><a href="https://ubuntu.com/kubeflow/what-is-kubeflow">What is Kubeflow?</a></li>
-      </ul>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--suru-dark">
-  <div class="row u-equal-height">
-    <div class="col-7 u-vertically-center">
-      <div>
-        <h2>Katib introduced by AutoML</h2>
-        <p>Charmed Kubeflow includes Katib to simplify model hyperparameter tuning and neural architecture search experiments.</p>
-        <p>Find the best ML model faster with Charmed Kubeflow and Katib.</p>
+  </section>
+  <section class="p-strip--suru-dark">
+    <div class="row u-equal-height">
+      <div class="col-7 u-vertically-center">
+        <div>
+          <h2>Katib introduced by AutoML</h2>
+          <p>
+            Charmed Kubeflow includes Katib to simplify model hyperparameter tuning and neural architecture search experiments.
+          </p>
+          <p>Find the best ML model faster with Charmed Kubeflow and Katib.</p>
+        </div>
       </div>
-    </div>
-    <div class="col-5 u-align--center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/d89128ff-Katib_logo.svg",
-          alt="",
-          width="324",
-          height="302",
-          hi_def=True,
-        ) | safe
-      }}
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row u-equal-height">
-    <div class="col-5 u-align--center u-hide--small u-hide--medium u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/5307db8d-Kubeflow+services.svg",
-          alt="",
-          width="279",
-          height="300",
-          hi_def=True,
-        ) | safe
-      }}
-    </div>
-    <div class="col-7">
-      <p class="p-muted-heading">Kubeflow support</p>
-      <h2>All&ndash;you&ndash;need support services</h2>
-      <p class="p-heading--4 u-sv2">Enterprise support, deployment and fully managed Charmed&nbsp;Kubeflow</p>
-      <p>Rely on 24/7 full-stack enterprise support with the SLAs you need.</p>
-      <p>Offload deployment and management to Canonical's engineers.</p>
-      <p>
-        <a href="https://assets.ubuntu.com/v1/4e502b09-Managed.Kubeflow.DS.19.01.22+%281%29.pdf" class="p-button--positive">Get the datasheet</a>
-        <a href="#get-in-touch" class="js-invoke-modal p-button">Contact us&nbsp;&rsaquo;</a>
-      </p>
-      <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a href="https://ubuntu.com/managed/apps">Managed Kubeflow</a></li>
-        <li class="p-inline-list__item"><a href="http://ubuntu.com/kubeflow/consulting">Kubeflow services</a></li>
-      </ul>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h2>Automatic GPU acceleration</h2>
-      <p class="p-heading--4 u-sv2">Easily detect, configure and accelerate deep learning</p>
-      <p>Accelerate your AI time to market. Pass GPUs to your ML pipelines, for deep learning training and validation.</p>
-      <p>Train faster on the latest silicon, including NVIDIA® Ampere. Charmed Kubeflow will automagically detect, configure and use available GPUs.</p>
-      <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a href="https://charmed-kubeflow.io/docs/gpu">GPUs with Charmed Kubeflow&nbsp;&rsaquo;</a></li>
-      </ul>
-    </div>
-    <div class="col-4 u-align--center u-hide--small u-hide--medium u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/44a572ce-Automatic+GPU+acceleration.svg",
-          alt="",
-          width="246",
-          height="179",
-          hi_def=True,
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row u-equal-height">
-    <div class="col-4 u-align--center u-hide--small u-hide--medium u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/97c081fa-Scale+data.svg",
-          alt="",
-          width="300",
-          height="180",
-          hi_def=True,
-        ) | safe
-      }}
-    </div>
-    <div class="col-8">
-      <h2>Scale AI experiments to thousands of jobs</h2>
-      <p class="p-heading--4 u-sv2">Offer data scientists a platform for large-scale continuous AI/ML model training</p>
-      <p>Founded on Kubernetes, scaling machine learning with Charmed Kubeflow is painless.</p>
-      <p>Multi-cloud Charmed Kubeflow delivers the elasticity of the public clouds with the governance of on-premise deployment.</p>
-      <p>Train your team once to work anywhere.</p>
-      <p>
-        <a href="/docs/install" class="p-button">Run Charmed Kubeflow at scale</a>
-      </p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h2>Data lake integration</h2>
-      <p class="p-heading--4 u-sv2">Big data and event streaming. Turn data into predictions.</p>
-      <p>Harness the full potential of your data hub by integrating Charmed Kubeflow to deliver advanced, continuous AI inference.</p>
-      <p>Looking to accelerate your data engineering and MLOps initiatives? Need to integrate with Spark or Kafka? We’ll help you connect the dots.</p>
-      <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a href="#get-in-touch" class="js-invoke-modal">Talk to us about integration&nbsp;&rsaquo;</a></li>
-      </ul>
-    </div>
-    <div class="col-5 u-vertically-center p-logo-section">
-      <div class="p-logo-section__items" style="margin: .5rem">
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/5ecd8306-Apache_Spark_logo.svg",
-              alt="Apache Spark",
-              width="148",
-              height="78",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-            ) | safe
+      <div class="col-5 u-align--center">
+        {{ image(url="https://assets.ubuntu.com/v1/d89128ff-Katib_logo.svg",
+                alt="",
+                width="324",
+                height="302",
+                hi_def=True,) | safe
+        }}
+      </div>
+    </section>
+    <section class="p-strip">
+      <div class="row u-equal-height">
+        <div class="col-5 u-align--center u-hide--small u-hide--medium u-vertically-center">
+          {{ image(url="https://assets.ubuntu.com/v1/5307db8d-Kubeflow+services.svg",
+                    alt="",
+                    width="279",
+                    height="300",
+                    hi_def=True,) | safe
           }}
         </div>
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/c2a4ebd4-Kafka.svg",
-              alt="Kafka",
-              width="147",
-              height="68",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
+        <div class="col-7">
+          <p class="p-muted-heading">Kubeflow support</p>
+          <h2>All&ndash;you&ndash;need support services</h2>
+          <p class="p-heading--4 u-sv2">Enterprise support, deployment and fully managed Charmed&nbsp;Kubeflow</p>
+          <p>Rely on 24/7 full-stack enterprise support with the SLAs you need.</p>
+          <p>Offload deployment and management to Canonical's engineers.</p>
+          <p>
+            <a href="https://assets.ubuntu.com/v1/4e502b09-Managed.Kubeflow.DS.19.01.22+%281%29.pdf"
+               class="p-button--positive">Get the datasheet</a>
+            <a href="#get-in-touch" class="js-invoke-modal p-button">Contact us&nbsp;&rsaquo;</a>
+          </p>
+          <ul class="p-inline-list">
+            <li class="p-inline-list__item">
+              <a href="https://ubuntu.com/managed/apps">Managed Kubeflow</a>
+            </li>
+            <li class="p-inline-list__item">
+              <a href="http://ubuntu.com/kubeflow/consulting">Kubeflow services</a>
+            </li>
+          </ul>
         </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row u-equal-height">
-    <div class="col-4 u-hide--small u-hide--medium p-logo-section">
-      <div class="p-logo-section__items u-vertically-center" style="margin: .5rem">
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/8e871a40-MLflow-Logo.svg",
-              alt="",
-              width="437",
-              height="160",
-              hi_def=True,
-            ) | safe
-          }}
-	</div>
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/e227c0b2-seldon.d08abf3e.png",
-              alt="",
-              width="410",
-              height="220",
-              hi_def=True,
-            ) | safe
-          }}
-	</div>
-	<div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/5ecd8306-Apache_Spark_logo.svg",
-              alt="",
-              width="410",
-              height="220",
-              hi_def=True,
-            ) | safe
+      </div>
+    </section>
+    <section class="p-strip--light">
+      <div class="row u-equal-height">
+        <div class="col-7">
+          <h2>Automatic GPU acceleration</h2>
+          <p class="p-heading--4 u-sv2">Easily detect, configure and accelerate deep learning</p>
+          <p>Accelerate your AI time to market. Pass GPUs to your ML pipelines, for deep learning training and validation.</p>
+          <p>
+            Train faster on the latest silicon, including NVIDIA® Ampere. Charmed Kubeflow will automagically detect, configure and use available GPUs.
+          </p>
+          <ul class="p-inline-list">
+            <li class="p-inline-list__item">
+              <a href="https://charmed-kubeflow.io/docs/gpu">GPUs with Charmed Kubeflow&nbsp;&rsaquo;</a>
+            </li>
+          </ul>
+        </div>
+        <div class="col-4 u-align--center u-hide--small u-hide--medium u-vertically-center">
+          {{ image(url="https://assets.ubuntu.com/v1/44a572ce-Automatic+GPU+acceleration.svg",
+                    alt="",
+                    width="246",
+                    height="179",
+                    hi_def=True,) | safe
           }}
         </div>
       </div>
-    </div>
-    <div class="col-8">
-      <h2>Open source data operations</h2>
-      <p class="p-heading--4 u-sv2">Composable, model-driven solutions</p>
-      <p>Make use of open source integration code and compound the benefit of <a href="https://charmhub.io/">300+ available Juju charm operators</a>.</p>
-      <p>The Juju charm operator solution from Canonical makes deploying and managing Charmed Kubeflow predictable, repeatable and reliable for your IT operations team. Zero friction, from proof-of-concept to production.</p>
-      <p>Engineered for flexibility around complex scenarios, the Juju charms extended ecosystem allows you to tailor Charmed Kubeflow to your needs with additional integrations &mdash; like MLFlow, Apache Spark and Seldon Core.</p>
-      <p>
-        <a href="https://jaas.ai/kubeflow/bundle" class="p-button--neurtal">Kubeflow charms and models&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-7">
-      <h2>Optimised for every cloud</h2>
-      <p class="p-heading--4 u-sv2">Fast AI predictions on every major cloud with GPU acceleration</p>
-      <p>We work with Amazon AWS, Microsoft Azure, Google and Oracle clouds to simplify multi-cloud, GPU accelerated AI.</p>
-      <p>Easy setup across cloud Kubernetes services for a multi-cloud MLOps platform. Get the elasticity of the public clouds with the governance of on-premise service management. Separate training from production environments as required &mdash; hybrid cloud is also supported.</p>
-      <p>Automated deployment and management with Canonical's Juju charm model-driven operator solution. Support for major cloud Kubernetes services including Azure AKS, AWS EKS and Google GKE.</p>
-      <p><a href="https://ubuntu.com/kubernetes">Kubeflow on multi-cloud K8s&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-5 u-vertically-center p-logo-section">
-      <div class="p-logo-section__items" style="margin: .5rem">
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/e7a3c4d8-MicrosoftAzure.svg",
-              alt="Microsoft Azure",
-              width="174",
-              height="50",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-            ) | safe
+    </section>
+    <section class="p-strip">
+      <div class="row u-equal-height">
+        <div class="col-4 u-align--center u-hide--small u-hide--medium u-vertically-center">
+          {{ image(url="https://assets.ubuntu.com/v1/97c081fa-Scale+data.svg",
+                    alt="",
+                    width="300",
+                    height="180",
+                    hi_def=True,) | safe
           }}
         </div>
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg",
-              alt="AWS",
-              width="107",
-              height="64",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/6e176d9a-Google+Cloud+stacked.svg",
-              alt="Google Cloud",
-              width="120",
-              height="99",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/cb2c8b1f-Oracle.svg",
-              alt="Oracle",
-              width="192",
-              height="25",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row">
-    <div class="col-5 u-vertically-center u-hide--small u-hide--medium p-logo-section">
-      <div class="p-logo-section__items">
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/97e29c13-Dell.svg",
-              alt="Dell",
-              width="90",
-              height="90",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg",
-              alt="NVIDIA",
-              width="120",
-              height="100",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/182d5546-logo-hp.png",
-              alt="HP",
-              width="80",
-              height="80",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item" style="margin: 1.875rem">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/7c91270a-Lenovo.svg",
-              alt="Lenovo",
-              width="165",
-              height="35",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
+        <div class="col-8">
+          <h2>Scale AI experiments to thousands of jobs</h2>
+          <p class="p-heading--4 u-sv2">Offer data scientists a platform for large-scale continuous AI/ML model training</p>
+          <p>Founded on Kubernetes, scaling machine learning with Charmed Kubeflow is painless.</p>
+          <p>
+            Multi-cloud Charmed Kubeflow delivers the elasticity of the public clouds with the governance of on-premise deployment.
+          </p>
+          <p>Train your team once to work anywhere.</p>
+          <p>
+            <a href="/docs/install" class="p-button">Run Charmed Kubeflow at scale</a>
+          </p>
         </div>
       </div>
-    </div>
-    <div class="col-7">
-      <h2>Full-stack Charmed Kubeflow</h2>
-      <p class="p-heading--4 u-sv2">Get your AI initiative up and running fast with integrated, proven solutions.</p>
-      <p>We work with system vendors like Dell, Lenovo, HP and NVIDIA to bring the best out-of-the-box MLOps experience to the data centre.</p>
-      <p>Operate a bare-metal Kubernetes cloud on-premise with <a href="http://maas.io">Metal As A Service</a>.</p>
-      <p>Canonical's Juju charm model-driven operator solution for Charmed Kubeflow delivers a horizontally scalable, integrated data science system for AI. Includes Canonical Observability Stack, Ceph storage system, Charmed Kubernetes and the Charmed Kubeflow MLOps platform. All with full, 24/7 support available from Canonical.</p>
-      <ul class="p-inline-list">
-	<li class="p-inline-list__item"><a href="https://lenovopress.com/lp1415-canonical-charmed-kubernetes-on-thinksystem-for-ai-development">Lenovo AI Development Reference Architecture</a></li>
-      </ul>
-      <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a href="https://ubuntu.com/engage/dell-kubeflow-reference-architecture">Dell and Canonical Reference Architecture</a></li>
-        <li class="p-inline-list__item"><a href="/contact-us" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a></li>
-      </ul>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-7">
-      <h2>The MLOps on Kubernetes experts</h2>
-      <p>Charmed Kubeflow is complemented by other Kubernetes solutions available from Canonical, including MicroK8s and Charmed Kubernetes.</p>
-      <p><a href="http://microk8s.io">MicroK8s</a> is the tiny yet mighty, opinionated zero-ops Kubernetes distribution. Easily build a distributed MLOps environment in record time.</p>
-      <p><a href="https://ubuntu.com/kubernetes/install#cluster">Charmed Kubernetes</a> delivers full flexibility and comprehensive control. Deliver a world-class data science cluster at epic scale.</p>
-    </div>
-    <div class="col-3 u-align--center u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
-          alt="",
-          width="480",
-          height="65",
-          hi_def=True,
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row u-equal-height">
-    <div class="col-3 col-start-large-2 u-align--center u-hide--small u-hide--medium u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/24a03775-Contact+us.svg",
-          alt="",
-          width="240",
-          height="171",
-          hi_def=True,
-        ) | safe
-      }}
-    </div>
-    <div class="col-7 col-start-large-6">
-      <h3>Need help?</h3>
-      <p>Get in touch with one of our experts now to find out more about Canonical's 24/7 expert services for MLOps environments running Charmed Kubeflow.</p>
-      <p>
-        <a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
-      </p>
-    </div>
-  </div>
-</section>
-{% endblock %}
+    </section>
+    <section class="p-strip--light">
+      <div class="row u-equal-height">
+        <div class="col-7">
+          <h2>Data lake integration</h2>
+          <p class="p-heading--4 u-sv2">Big data and event streaming. Turn data into predictions.</p>
+          <p>
+            Harness the full potential of your data hub by integrating Charmed Kubeflow to deliver advanced, continuous AI inference.
+          </p>
+          <p>
+            Looking to accelerate your data engineering and MLOps initiatives? Need to integrate with Spark or Kafka? We’ll help you connect the dots.
+          </p>
+          <ul class="p-inline-list">
+            <li class="p-inline-list__item">
+              <a href="#get-in-touch" class="js-invoke-modal">Talk to us about integration&nbsp;&rsaquo;</a>
+            </li>
+          </ul>
+        </div>
+        <div class="col-5 u-vertically-center p-logo-section">
+          <div class="p-logo-section__items" style="margin: .5rem">
+            <div class="p-logo-section__item" style="margin: 1.875rem">
+              {{ image(url="https://assets.ubuntu.com/v1/5ecd8306-Apache_Spark_logo.svg",
+                            alt="Apache Spark",
+                            width="148",
+                            height="78",
+                            hi_def=True,
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item" style="margin: 1.875rem">
+              {{ image(url="https://assets.ubuntu.com/v1/c2a4ebd4-Kafka.svg",
+                            alt="Kafka",
+                            width="147",
+                            height="68",
+                            hi_def=True,
+                            attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+          </div>
+        </div>
+      </section>
+      <section class="p-strip">
+        <div class="row">
+          <div class="col-4 u-hide--small u-hide--medium ">
+            <div class="p-logo-section">
+              <div class="p-logo-section__items">
+                <div class="p-logo-section__item">
+                  <img class="p-logo-section__logo"
+                       src="https://assets.ubuntu.com/v1/8e871a40-MLflow-Logo.svg"
+                       style="width: 12rem" />
+                </div>
+                <div class="p-logo-section__item">
+                  <img class="p-logo-section__logo"
+                       src="https://assets.ubuntu.com/v1/e227c0b2-seldon.d08abf3e.png"
+                       style="width: 12rem;
+                              margin-top: 0.8rem;
+                              margin-bottom: 1.6rem" />
+                </div>
+                <div class="p-logo-section__item">
+                  <img class="p-logo-section__logo"
+                       src="https://assets.ubuntu.com/v1/5ecd8306-Apache_Spark_logo.svg"
+                       style="width: 12rem" />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="col-8">
+            <h2>Open source data operations</h2>
+            <p class="p-heading--4 u-sv2">Composable, model-driven solutions</p>
+            <p>
+              Make use of open source integration code and compound the benefit of <a href="https://charmhub.io/">300+ available Juju charm operators</a>.
+            </p>
+            <p>
+              The Juju charm operator solution from Canonical makes deploying and managing Charmed Kubeflow predictable, repeatable and reliable for your IT operations team. Zero friction, from proof-of-concept to production.
+            </p>
+            <p>
+              Engineered for flexibility around complex scenarios, the Juju charms extended ecosystem allows you to tailor Charmed Kubeflow to your needs with additional integrations &mdash; like MLFlow, Apache Spark and Seldon Core.
+            </p>
+            <p>
+              <a href="https://jaas.ai/kubeflow/bundle" class="p-button--neurtal">Kubeflow charms and models&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </section>
+      <section class="p-strip--light">
+        <div class="row">
+          <div class="col-7">
+            <h2>Optimised for every cloud</h2>
+            <p class="p-heading--4 u-sv2">Fast AI predictions on every major cloud with GPU acceleration</p>
+            <p>We work with Amazon AWS, Microsoft Azure, Google and Oracle clouds to simplify multi-cloud, GPU accelerated AI.</p>
+            <p>
+              Easy setup across cloud Kubernetes services for a multi-cloud MLOps platform. Get the elasticity of the public clouds with the governance of on-premise service management. Separate training from production environments as required &mdash; hybrid cloud is also supported.
+            </p>
+            <p>
+              Automated deployment and management with Canonical's Juju charm model-driven operator solution. Support for major cloud Kubernetes services including Azure AKS, AWS EKS and Google GKE.
+            </p>
+            <p>
+              <a href="https://ubuntu.com/kubernetes">Kubeflow on multi-cloud K8s&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="col-5 u-hide--small u-hide--medium ">
+            <div class="p-logo-section">
+              <div class="p-logo-section__items">
+                <div class="p-logo-section__item">
+                  <img class="p-logo-section__logo"
+                       src="https://assets.ubuntu.com/v1/e7a3c4d8-MicrosoftAzure.svg"
+                       style="height: 3rem; margin: 2rem;" />
+                </div>
+                <div class="p-logo-section__item">
+                  <img class="p-logo-section__logo"
+                       src="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg"
+                       style="height: 3rem; margin: 2rem;" />
+                </div>
+                <div class="p-logo-section__item">
+                  <img class="p-logo-section__logo"
+                       src="https://assets.ubuntu.com/v1/6e176d9a-Google+Cloud+stacked.svg"
+                       style="height: 3rem; margin: 2rem;" />
+                </div>
+                <div class="p-logo-section__item">
+                  <img class="p-logo-section__logo"
+                       src="https://assets.ubuntu.com/v1/cb2c8b1f-Oracle.svg"
+                       style="height: 3rem; margin: 2rem;" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section class="p-strip">
+        <div class="row">
+          <div class="col-6 u-vertically-center u-hide--small u-hide--medium p-logo-section">
+            <div class="p-logo-section">
+              <div class="p-logo-section__items">
+                <div class="p-logo-section__item" style="margin: 1.875rem">
+                  {{ image(url="https://assets.ubuntu.com/v1/97e29c13-Dell.svg",
+                                    alt="Dell",
+                                    width="60",
+                                    height="60",
+                                    hi_def=True,
+                                    attrs={"class": "p-logo-section__logo"},) | safe
+                  }}
+                </div>
+                <div class="p-logo-section__item" style="margin: 1.875rem">
+                  {{ image(url="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg",
+                                    alt="NVIDIA",
+                                    width="60",
+                                    height="50",
+                                    hi_def=True,
+                                    attrs={"class": "p-logo-section__logo"},) | safe
+                  }}
+                </div>
+                <div class="p-logo-section__item" style="margin: 1.875rem">
+                  {{ image(url="https://assets.ubuntu.com/v1/182d5546-logo-hp.png",
+                                    alt="HP",
+                                    width="60",
+                                    height="60",
+                                    hi_def=True,
+                                    attrs={"class": "p-logo-section__logo"},) | safe
+                  }}
+                </div>
+                <div class="p-logo-section__item" style="margin: 1.875rem">
+                  {{ image(url="https://assets.ubuntu.com/v1/7c91270a-Lenovo.svg",
+                                    alt="Lenovo",
+                                    width="165",
+                                    height="35",
+                                    hi_def=True,
+                                    attrs={"class": "p-logo-section__logo"},) | safe
+                  }}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="col-6">
+            <h2>Full-stack Charmed Kubeflow</h2>
+            <p class="p-heading--4 u-sv2">Get your AI initiative up and running fast with integrated, proven solutions.</p>
+            <p>
+              We work with system vendors like Dell, Lenovo, HP and NVIDIA to bring the best out-of-the-box MLOps experience to the data centre.
+            </p>
+            <p>
+              Operate a bare-metal Kubernetes cloud on-premise with <a href="http://maas.io">Metal As A Service</a>.
+            </p>
+            <p>
+              Canonical's Juju charm model-driven operator solution for Charmed Kubeflow delivers a horizontally scalable, integrated data science system for AI. Includes Canonical Observability Stack, Ceph storage system, Charmed Kubernetes and the Charmed Kubeflow MLOps platform. All with full, 24/7 support available from Canonical.
+            </p>
+            <ul class="p-inline-list">
+              <li class="p-inline-list__item">
+                <a href="https://lenovopress.com/lp1415-canonical-charmed-kubernetes-on-thinksystem-for-ai-development">Lenovo AI Development Reference Architecture</a>
+              </li>
+            </ul>
+            <ul class="p-inline-list">
+              <li class="p-inline-list__item">
+                <a href="https://ubuntu.com/engage/dell-kubeflow-reference-architecture">Dell and Canonical Reference Architecture</a>
+              </li>
+              <li class="p-inline-list__item">
+                <a href="/contact-us" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+      <section class="p-strip--light">
+        <div class="row">
+          <div class="col-7">
+            <h2>The MLOps on Kubernetes experts</h2>
+            <p>
+              Charmed Kubeflow is complemented by other Kubernetes solutions available from Canonical, including MicroK8s and Charmed Kubernetes.
+            </p>
+            <p>
+              <a href="http://microk8s.io">MicroK8s</a> is the tiny yet mighty, opinionated zero-ops Kubernetes distribution. Easily build a distributed MLOps environment in record time.
+            </p>
+            <p>
+              <a href="https://ubuntu.com/kubernetes/install#cluster">Charmed Kubernetes</a> delivers full flexibility and comprehensive control. Deliver a world-class data science cluster at epic scale.
+            </p>
+          </div>
+          <div class="col-3 u-align--center u-vertically-center">
+            {{ image(url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
+                        alt="",
+                        width="480",
+                        height="65",
+                        hi_def=True,) | safe
+            }}
+          </div>
+        </div>
+      </section>
+      <section class="p-strip">
+        <div class="row u-equal-height">
+          <div class="col-3 col-start-large-2 u-align--center u-hide--small u-hide--medium u-vertically-center">
+            {{ image(url="https://assets.ubuntu.com/v1/24a03775-Contact+us.svg",
+                        alt="",
+                        width="240",
+                        height="171",
+                        hi_def=True,) | safe
+            }}
+          </div>
+          <div class="col-7 col-start-large-6">
+            <h3>Need help?</h3>
+            <p>
+              Get in touch with one of our experts now to find out more about Canonical's 24/7 expert services for MLOps environments running Charmed Kubeflow.
+            </p>
+            <p>
+              <a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+            </p>
+          </div>
+        </div>
+      </section>
+    {% endblock %}

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,19 +1,19 @@
-<footer class="p-strip--light">
+{% macro footer_contents() %}
   <div class="row">
     <div class="col-12">
       <p>&copy; {{ now("%Y") }} Canonical Ltd.</p>
       <nav>
         <ul class="p-inline-list--middot">
           <li class="p-inline-list__item">
-            <a aria-label="External link to the Ubuntu legal information page" href="http://www.ubuntu.com/legal">
-              Legal information
-            </a>
+            <a aria-label="External link to the Ubuntu legal information page"
+               href="http://www.ubuntu.com/legal">Legal information</a>
           </li>
           <li class="p-inline-list__item">
             <a class="js-revoke-cookie-manager" href="">Manage your tracker settings</a>
           </li>
           <li class="p-inline-list__item">
-            <a aria-label="External link to report a bug on this site" href="https://github.com/canonical-web-and-design/charmed-kubeflow.io/issues/new">
+            <a aria-label="External link to report a bug on this site"
+               href="https://github.com/canonical-web-and-design/charmed-kubeflow.io/issues/new">
               Report a bug on this site
             </a>
           </li>
@@ -24,4 +24,17 @@
       </nav>
     </div>
   </div>
-</footer>
+{% endmacro %}
+{% if is_docs %}
+  <div class="p-strip--light footer l-docs__subgrid">
+    <div class="l-docs__main">
+      <footer class="footer">
+        {{ footer_contents() }}
+      </footer>
+    </div>
+  </div>
+{% else %}
+  <footer class="p-strip--light">
+    {{ footer_contents() }}
+  </footer>
+{% endif %}

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -1,36 +1,57 @@
-<header id="navigation" class="p-navigation is-dark">
-  <div class="p-navigation__row">
-    <div class="p-navigation__banner">
-      <div class="p-navigation__tagged-logo">
-        <a class="p-navigation__link" href="/">
-          <div class="p-navigation__logo-tag">
-            <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
-          </div>
-          <span class="p-navigation__logo-title">Canonical Kubeflow</span>
-        </a>
-      </div>
-      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+{% macro nav_logo() %}
+  <div class="p-navigation__banner">
+    <div class="p-navigation__tagged-logo">
+      <a class="p-navigation__link" href="/">
+        <div class="p-navigation__logo-tag">
+          <img class="p-navigation__logo-icon"
+               src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg"
+               alt="" />
+        </div>
+        <span class="p-navigation__logo-title">Canonical Kubeflow</span>
+      </a>
     </div>
-
-    <nav class="p-navigation__nav">
-      <ul class="p-navigation__items">
-        <li class="p-navigation__item {% if request.path.startswith('/docs') %}is-selected{% endif %}">
-          <a class="p-navigation__link" href="/docs">Docs</a>
-        </li>
-        <li class="p-navigation__item">
-          <a class="p-navigation__link" href="https://github.com/juju-solutions/bundle-kubeflow">Code</a>
-        </li>
-        <li class="p-navigation__item">
-          <a class="p-navigation__link" href="https://github.com/juju-solutions/bundle-kubeflow/issues">Bugs</a>
-        </li>
-        <li class="p-navigation__item">
-          <a class="p-navigation__link" href="https://discourse.charmhub.io/tags/kubeflow">Community</a>
-        </li>
-      </ul>
-      <ul class="p-navigation__items global-nav"></ul>
-    </nav>
+    <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+    <a href="#navigation-closed"
+       class="p-navigation__toggle--close"
+       title="close menu">Close menu</a>
   </div>
+{% endmacro %}
+{% macro nav_items() %}
+  <nav class="p-navigation__nav">
+    <ul class="p-navigation__items">
+      <li class="p-navigation__item {% if request.path.startswith('/docs') %}is-selected{% endif %}">
+        <a class="p-navigation__link" href="/docs">Docs</a>
+      </li>
+      <li class="p-navigation__item">
+        <a class="p-navigation__link"
+           href="https://github.com/juju-solutions/bundle-kubeflow">Code</a>
+      </li>
+      <li class="p-navigation__item">
+        <a class="p-navigation__link"
+           href="https://github.com/juju-solutions/bundle-kubeflow/issues">Bugs</a>
+      </li>
+      <li class="p-navigation__item">
+        <a class="p-navigation__link"
+           href="https://discourse.charmhub.io/tags/kubeflow">Community</a>
+      </li>
+    </ul>
+    <ul class="p-navigation__items global-nav">
+    </ul>
+  </nav>
+{% endmacro %}
+<header id="navigation" class="p-navigation is-dark">
+  {% if is_docs %}
+    <div class="l-docs__subgrid">
+      <div class="l-docs__sidebar">{{ nav_logo() }}</div>
+      <div class="l-docs__main">
+        <div class="p-navigation__row u-fixed-width">{{ nav_items() }}</div>
+      </div>
+    </div>
+  {% else %}
+    <div class="p-navigation__row--25-75">
+      {{ nav_logo() }}
+      {{ nav_items() }}
+    </div>
+  {% endif %}
 </header>
-
 <script src="{{ versioned_static('js/dist/global-nav.js') }}"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5562,15 +5562,15 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.15.1.tgz#3059f97e1fff68f3a274dd2950e2daa5409eeb21"
-  integrity sha512-wOHprZ01HyMByojT2RlhLL18Jq8P4U7wIfkMIH0fwjbR4HR6rbhaCbh1zh9Fkot+KBdgNQGTgqWw52liDtHmNA==
-
 vanilla-framework@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.0.0.tgz#a2fee9bd9763ebd6932b764f9d66484dc177d4cc"
   integrity sha512-fiPnmaTUe15l5MRNJ6IsiJ8qiunfmgtLETOFltaYiE/bQKL7xTI+riBak2iygBKeF1y0Gi/GxUNt4hyb6xDPKA==
+
+vanilla-framework@4.11.1:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.11.0.tgz#81636d58bacbd3320a4eb6bf5bef00409cfdc008"
+  integrity sha512-S0AAHNVphn3YJ7BQhyHmvKhrqiZcncQBPedwMan18uavB4VfAT8UN0dwgrHQvY/ypUuJiq/GPA0Xe1xcd+E7dg==
 
 verbalize@^0.1.2:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5567,7 +5567,7 @@ vanilla-framework@4.0.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.0.0.tgz#a2fee9bd9763ebd6932b764f9d66484dc177d4cc"
   integrity sha512-fiPnmaTUe15l5MRNJ6IsiJ8qiunfmgtLETOFltaYiE/bQKL7xTI+riBak2iygBKeF1y0Gi/GxUNt4hyb6xDPKA==
 
-vanilla-framework@4.11.1:
+vanilla-framework@4.11.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.11.0.tgz#81636d58bacbd3320a4eb6bf5bef00409cfdc008"
   integrity sha512-S0AAHNVphn3YJ7BQhyHmvKhrqiZcncQBPedwMan18uavB4VfAT8UN0dwgrHQvY/ypUuJiq/GPA0Xe1xcd+E7dg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5567,10 +5567,10 @@ vanilla-framework@4.0.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.0.0.tgz#a2fee9bd9763ebd6932b764f9d66484dc177d4cc"
   integrity sha512-fiPnmaTUe15l5MRNJ6IsiJ8qiunfmgtLETOFltaYiE/bQKL7xTI+riBak2iygBKeF1y0Gi/GxUNt4hyb6xDPKA==
 
-vanilla-framework@4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.11.0.tgz#81636d58bacbd3320a4eb6bf5bef00409cfdc008"
-  integrity sha512-S0AAHNVphn3YJ7BQhyHmvKhrqiZcncQBPedwMan18uavB4VfAT8UN0dwgrHQvY/ypUuJiq/GPA0Xe1xcd+E7dg==
+vanilla-framework@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
+  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check if the /docs page is working fine and you are able to see a right side navigation panel with the headings of the document.
- Check if the header, footer and search are well alinged, use [multipass](https://multipass.run/docs) as a reference for the layout.
- Here is the [demo](https://charmed-kubeflow-io-179.demos.haus/docs) generated for the PR.

## Issue / Card

Fixes # [WD-12460](https://warthogs.atlassian.net/browse/WD-12460)





[WD-12460]: https://warthogs.atlassian.net/browse/WD-12460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ