### PR TITLE
feat: Use different copyright in footer on docs pages

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,7 +1,11 @@
 {% macro footer_contents() %}
   <div class="row">
     <div class="col-12">
+      {% if is_docs %}
+      <p>Copyright &copy; {{ now("%Y") }} CC-BY-SA, Canonical Ltd</p>
+      {% else %}
       <p>&copy; {{ now("%Y") }} Canonical Ltd.</p>
+      {% endif %}
       <nav>
         <ul class="p-inline-list--middot">
           <li class="p-inline-list__item">


### PR DESCRIPTION
## Done

- Use different copyright in footer on docs pages, based on description in [the issue](https://warthogs.atlassian.net/browse/WD-12548)

## QA

- Go to https://charmed-kubeflow-io-181.demos.haus/ or any page that isn't /docs
- scroll to footer and see '© 2024 Canonical Ltd.'

- Go to https://charmed-kubeflow-io-181.demos.haus/docs or any page under /docs
- scroll to footer and see 'Copyright © 2024 CC-BY-SA, Canonical Ltd'


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12548

## Screenshots
Not docs:
![image](https://github.com/user-attachments/assets/4e90979d-692f-4e1b-b223-dfa7366c140d)

Docs:
![image](https://github.com/user-attachments/assets/8b457a83-9766-4265-bbfe-76e0fbe49bd2)

