### PR TITLE
Upgrade canonicalwebteam.search to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "postcss": "8.4.21",
     "postcss-cli": "10.1.0",
     "prettier": "2.8.2",
-    "vanilla-framework": "4.14.0",
+    "vanilla-framework": "4.16.0",
     "watch-cli": "0.2.3",
     "webpack": "5.75.0",
     "webpack-cli": "5.0.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-canonicalwebteam.flask-base==1.1.0
+canonicalwebteam.flask-base==2.0.0
 canonicalwebteam.discourse==5.5.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.search==1.3.0
+canonicalwebteam.search==2.1.1
 

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -122,7 +122,7 @@
   <div class="l-docs__main u-fixed-width">
     <main id="main-content">
       {{ document.body_html | safe }}
-      <hr />
+      <hr class="p-rule" />
       <p>
         <i>Last updated {{ document.updated }}.</i>
       </p>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -38,9 +38,11 @@ app.add_url_rule(
     "/docs/search",
     "docs-search",
     build_search_view(
+        app=app,
         session=session,
         site="charmed-kubeflow.io/docs",
         template_path="docs/search.html",
+        request_limit="1/day",
     ),
 )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -42,7 +42,6 @@ app.add_url_rule(
         session=session,
         site="charmed-kubeflow.io/docs",
         template_path="docs/search.html",
-        request_limit="1/day",
     ),
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5567,10 +5567,10 @@ vanilla-framework@4.0.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.0.0.tgz#a2fee9bd9763ebd6932b764f9d66484dc177d4cc"
   integrity sha512-fiPnmaTUe15l5MRNJ6IsiJ8qiunfmgtLETOFltaYiE/bQKL7xTI+riBak2iygBKeF1y0Gi/GxUNt4hyb6xDPKA==
 
-vanilla-framework@4.14.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
-  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
+vanilla-framework@4.16.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.16.0.tgz#54e7a51e073de043d45a7bac37ffaa4f4351ac4a"
+  integrity sha512-LrxZLiNOm0cTpG++1X4MMy2efg8Xhc08JUAwNAybeSQ5FaaBGiAodbV1Fx3QvJxlaPFQqsjOdT6uZDwuOD7YJg==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION

## Done

- Upgrade canonicalwebteam.search to 2.1.1
- Upgrade canonicalwebteam.flask-base to 2.0.0
- Pass `app` to `build_search_view()`
- Bump vanilla-framework to 4.16.0
- Add `p-rule` class to `<hr>`s

## QA

- Go to https://charmed-kubeflow-io-182.demos.haus/docs/search
- Search something
- See rate limit is hit (currently set to 1, so you can search 1 time before hitting it)


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-15017

## Screenshots

![image](https://github.com/user-attachments/assets/9d3af5d2-71c2-43bd-a167-e1bc2dc869e4)
